### PR TITLE
Validate session allows either session or refresh to be empty

### DIFF
--- a/lib/index.test.ts
+++ b/lib/index.test.ts
@@ -3,7 +3,9 @@ import { JWK, SignJWT, exportJWK, JWTHeaderParameters, generateKeyPair } from 'j
 import { refreshTokenCookieName, sessionTokenCookieName } from './constants'
 import createSdk from '.'
 
-let validToken: string; let expiredToken: string; let publicKeys: JWK
+let validToken: string
+let expiredToken: string
+let publicKeys: JWK
 
 const logger = {
   log: jest.fn(),

--- a/lib/index.test.ts
+++ b/lib/index.test.ts
@@ -107,6 +107,11 @@ describe('sdk', () => {
         token: { exp: 1981398111, iss: 'project-id' },
       })
     })
+    it('should throw an error when session token expired and no refresh token', async () => {
+      await expect(sdk.validateSession(expiredToken, '')).rejects.toThrow(
+        'could not validate tokens',
+      )
+    })
     it('should throw an error when both refresh & session tokens expired', async () => {
       await expect(sdk.validateSession(expiredToken, expiredToken)).rejects.toThrow(
         'could not validate tokens',

--- a/lib/index.test.ts
+++ b/lib/index.test.ts
@@ -92,9 +92,9 @@ describe('sdk', () => {
   })
 
   describe('ValidateSession', () => {
-    it('should throw an error when session token is empty', async () => {
-      await expect(sdk.validateSession('', validToken)).rejects.toThrow(
-        'session token must not be empty',
+    it('should throw an error when both session and refresh tokens are empty', async () => {
+      await expect(sdk.validateSession('', '')).rejects.toThrow(
+        'both refresh token and session token are empty',
       )
     })
     it('should return the token when session token is valid', async () => {
@@ -113,6 +113,14 @@ describe('sdk', () => {
         .mockResolvedValueOnce({ data: 'data' } as SdkResponse)
 
       await expect(sdk.validateSession(expiredToken, validToken)).resolves.toEqual('data')
+      expect(spyRefresh).toHaveBeenCalledWith(validToken)
+    })
+    it('should return the token when refresh token is valid', async () => {
+      const spyRefresh = jest
+        .spyOn(sdk, 'refresh')
+        .mockResolvedValueOnce({ data: 'data' } as SdkResponse)
+
+      await expect(sdk.validateSession('', validToken)).resolves.toEqual('data')
       expect(spyRefresh).toHaveBeenCalledWith(validToken)
     })
   })

--- a/lib/index.test.ts
+++ b/lib/index.test.ts
@@ -3,7 +3,7 @@ import { JWK, SignJWT, exportJWK, JWTHeaderParameters, generateKeyPair } from 'j
 import { refreshTokenCookieName, sessionTokenCookieName } from './constants'
 import createSdk from '.'
 
-let validToken: string, expiredToken: string, publicKeys: JWK
+let validToken: string; let expiredToken: string; let publicKeys: JWK
 
 const logger = {
   log: jest.fn(),

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -90,26 +90,20 @@ const sdk = (...args: Parameters<typeof createSdk>) => {
           const token = await this.validateToken(sessionToken)
           return token
         } catch (error) {
-          if (refreshToken) {
-            try {
-              await this.validateToken(refreshToken)
-              return (await this.refresh(refreshToken)).data
-            } catch (refreshTokenErr) {
-              logger?.error('failed to validate refresh token', refreshTokenErr)
-              throw Error('could not validate tokens')
-            }
+          if (!refreshToken) {
+            logger?.error('failed to validate session token and no refresh token provided', error)
+            throw Error('could not validate tokens')
           }
-          logger?.error('failed to validate session token and no refresh token provided', error)
-          throw Error('could not validate tokens')
         }
       }
-      // We are here so sessionToken was not provided
-      try {
-        await this.validateToken(refreshToken)
-        return (await this.refresh(refreshToken)).data
-      } catch (refreshTokenErr) {
-        logger?.error('failed to validate refresh token', refreshTokenErr)
-        throw Error('could not validate tokens')
+      if (refreshToken) {
+        try {
+          await this.validateToken(refreshToken)
+          return (await this.refresh(refreshToken)).data
+        } catch (refreshTokenErr) {
+          logger?.error('failed to validate refresh token', refreshTokenErr)
+          throw Error('could not validate tokens')
+        }
       }
     },
   }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -72,7 +72,8 @@ const sdk = (...args: Parameters<typeof createSdk>) => {
     },
 
     async validateToken(token: string): Promise<AuthenticationInfo> {
-      const res = await jwtVerify(token, this.getKey, { algorithms: ['ES384'] })
+      // Do not hard-code the algo because library does not support `None` so all are valid
+      const res = await jwtVerify(token, this.getKey, { issuer: projectId, clockTolerance: 5 })
 
       return { token: res.payload }
     },

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -5,6 +5,7 @@ import { bulkWrapWith, withCookie } from './helpers'
 import { AuthenticationInfo } from './types'
 import { refreshTokenCookieName, sessionTokenCookieName } from './constants'
 
+/* istanbul ignore next */
 if (!globalThis.fetch) {
   // @ts-ignore
   globalThis.fetch = fetch
@@ -105,6 +106,7 @@ const sdk = (...args: Parameters<typeof createSdk>) => {
           throw Error('could not validate tokens')
         }
       }
+      /* istanbul ignore next */
       throw Error('could not validate token')
     },
   }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -105,6 +105,7 @@ const sdk = (...args: Parameters<typeof createSdk>) => {
           throw Error('could not validate tokens')
         }
       }
+      throw Error('could not validate token')
     },
   }
 }


### PR DESCRIPTION
## Description
Allow for session token to be empty if refresh token is there and valid. Use case is when we somehow have a refresh cookie but not yet a session cookie. Example might be if someone logs in using Passwordle (front-end to Descope), refresh cookie is returned and is configured on the main domain (`descope.com`) and now she goes to the console and should be auto-logged-in (console is backend to Descope). Passwordle will not set the session cookie from JS as it is not secure.
