### PR TITLE
fix sdk bundle with examples

### DIFF
--- a/examples/commonjs/package-lock.json
+++ b/examples/commonjs/package-lock.json
@@ -15,11 +15,11 @@
     },
     "../..": {
       "name": "@descope/node-sdk",
-      "version": "1.0.4-alpha.6",
+      "version": "1.0.4-alpha.9",
       "license": "MIT",
       "dependencies": {
-        "@descope/core-js-sdk": "0.0.41-alpha.24",
-        "jose": "4.10.0",
+        "@descope/core-js-sdk": "0.0.41-alpha.34",
+        "jose": "4.11.1",
         "node-fetch": "2.6.7"
       },
       "devDependencies": {
@@ -8375,7 +8375,7 @@
     "@descope/node-sdk": {
       "version": "file:../..",
       "requires": {
-        "@descope/core-js-sdk": "0.0.41-alpha.24",
+        "@descope/core-js-sdk": "0.0.41-alpha.34",
         "@rollup/plugin-commonjs": "^22.0.0",
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^13.3.0",
@@ -8402,7 +8402,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "husky": "^8.0.1",
         "jest": "^28.1.0",
-        "jose": "4.10.0",
+        "jose": "4.11.1",
         "jsdoc": "^3.6.10",
         "lint-staged": "^13.0.3",
         "nock": "^13.2.4",

--- a/examples/es6/package-lock.json
+++ b/examples/es6/package-lock.json
@@ -64,11 +64,11 @@
     },
     "../..": {
       "name": "@descope/node-sdk",
-      "version": "1.0.4-alpha.6",
+      "version": "1.0.4-alpha.9",
       "license": "MIT",
       "dependencies": {
-        "@descope/core-js-sdk": "0.0.41-alpha.24",
-        "jose": "4.10.0",
+        "@descope/core-js-sdk": "0.0.41-alpha.34",
+        "jose": "4.11.1",
         "node-fetch": "2.6.7"
       },
       "devDependencies": {
@@ -1763,7 +1763,7 @@
     "@descope/node-sdk": {
       "version": "file:../..",
       "requires": {
-        "@descope/core-js-sdk": "0.0.41-alpha.24",
+        "@descope/core-js-sdk": "0.0.41-alpha.34",
         "@rollup/plugin-commonjs": "^22.0.0",
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^13.3.0",
@@ -1790,7 +1790,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "husky": "^8.0.1",
         "jest": "^28.1.0",
-        "jose": "4.10.0",
+        "jose": "4.11.1",
         "jsdoc": "^3.6.10",
         "lint-staged": "^13.0.3",
         "nock": "^13.2.4",

--- a/examples/es6/src/index.ts
+++ b/examples/es6/src/index.ts
@@ -1,12 +1,12 @@
-import { SdkResponse } from '@descope/core-js-sdk';
-import express, { Request, Response, NextFunction } from 'express';
-import DescopeClient from '@descope/node-sdk';
+import { ResponseData, SdkResponse } from '@descope/core-js-sdk';
 import type { DeliveryMethod, OAuthProvider } from '@descope/node-sdk';
+import DescopeClient from '@descope/node-sdk';
+import bodyParser from 'body-parser';
+import express, { NextFunction, Request, Response } from 'express';
 import { readFileSync } from 'fs';
 import { createServer } from 'https';
 import path from 'path';
 import process from 'process';
-import bodyParser from 'body-parser';
 
 const app = express();
 app.use(bodyParser.json());
@@ -43,7 +43,7 @@ const authMiddleware = async (req: Request, res: Response, next: NextFunction) =
   }
 };
 
-const returnOK = (res: Response, out: SdkResponse<never>) => {
+const returnOK = <T extends ResponseData>(res: Response, out: SdkResponse<T>) => {
   res.setHeader('Content-Type', 'application/json');
   if (!out.ok) {
     res.status(400).send(out.error);
@@ -54,9 +54,8 @@ const returnOK = (res: Response, out: SdkResponse<never>) => {
   }
 };
 
-const returnCookies = (res: Response, out: SdkResponse<never>) => {
-  if (out.ok && out.data?.cookies) {
-    res.set('Set-Cookie', out.data.cookies);
+const returnCookies = <T extends ResponseData>(res: Response, out: SdkResponse<T>) => {
+  if (out.ok) {
     res.setHeader('Content-Type', 'application/json');
     res.status(200).send(out.data);
   } else {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,6 @@
     "typeRoots": ["./node_modules/@types"]
   },
 
-  "include": ["**/*.ts"],
+  "include": ["lib/**/*.ts"],
   "exclude": ["node_modules", "build", "dist", "test"]
 }


### PR DESCRIPTION
Related to https://github.com/descope/etc/issues/1207

## Description
Fixed node SDK example with the help of Nir

- the bundle is now containing only lib folder assets (and not `examples` folder)
```
➜  node-sdk git:(fix-node-bundle-and-examples) ll -R dist    
total 1608
drwxr-xr-x  5 asafshen  staff   160B Dec 14 14:16 cjs
-rw-r--r--  1 asafshen  staff    18K Dec 14 14:16 index.d.ts
-rw-r--r--  1 asafshen  staff   6.9K Dec 14 14:16 index.esm.js
-rw-r--r--  1 asafshen  staff    33K Dec 14 14:16 index.esm.js.map
-rw-r--r--  1 asafshen  staff   349K Dec 14 14:16 index.umd.js
-rw-r--r--  1 asafshen  staff   386K Dec 14 14:16 index.umd.js.map

dist/cjs:
total 96
-rw-r--r--  1 asafshen  staff   7.3K Dec 14 14:16 index.cjs.js
-rw-r--r--  1 asafshen  staff    33K Dec 14 14:16 index.cjs.js.map
-rw-r--r--  1 asafshen  staff    19B Dec 14 14:16 package.json
```

- fix examples compilation errors
 
