### PR TITLE
Add group support for management sdk  @dorsha

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,35 @@ rolesRes.data.forEach((role) => {
 });
 ```
 
+### ### Query SSO Groups
+
+You can query SSO groups:
+
+```typescript
+// Load all groups for a given tenant id
+const groupsRes = descopeClient.management.group.loadAllGroups('tenant-id');
+
+// Load all groups for the given user's jwt subjects (can be found in the user's JWT)
+const groupsRes = descopeClient.management.group.loadAllGroupsForMember('tenant-id', [
+  'jwt-subject-1',
+  'jwt-subject-2',
+]);
+
+// Load all groups for the given user's identifiers (used for sign-in)
+const groupsRes = descopeClient.management.group.loadAllGroupsForMember(
+  'tenant-id',
+  [],
+  ['identifier-1', 'identifier-2'],
+);
+
+// Load all group's members by the given group id
+const groupsRes = descopeClient.management.group.loadAllGroupMembers('tenant-id', 'group-id');
+
+groupsRes.data.forEach((group) => {
+  // do something
+});
+```
+
 ### Manage JWTs
 
 You can add custom claims to a valid JWT.

--- a/lib/management/group.test.ts
+++ b/lib/management/group.test.ts
@@ -1,0 +1,120 @@
+import { SdkResponse } from '@descope/core-js-sdk';
+import withManagement from '.';
+import apiPaths from './paths';
+import { mockCoreSdk, mockHttpClient } from './testutils';
+import { Group } from './types';
+
+const management = withManagement(mockCoreSdk, 'key');
+
+const mockGroups = [
+  { id: 'id1', display: 'display1', members: [] },
+  { name: 'id2', display: 'display2', members: [] },
+  { name: 'id3', display: 'display3', members: [] },
+];
+
+describe('Management group', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    mockHttpClient.reset();
+  });
+
+  describe('loadAllGroups', () => {
+    it('should send the correct request and receive correct response', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => mockGroups,
+        clone: () => ({
+          json: () => Promise.resolve(mockGroups),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const tenantId = 'tenant-id';
+      const resp: SdkResponse<Group[]> = await management.group.loadAllGroups(tenantId);
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        apiPaths.group.loadAllGroups,
+        { tenantId },
+        { token: 'key' },
+      );
+
+      expect(resp).toEqual({
+        code: 200,
+        ok: true,
+        response: httpResponse,
+        data: mockGroups,
+      });
+    });
+  });
+
+  describe('loadAllGroupsForMember', () => {
+    it('should send the correct request and receive correct response', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => mockGroups,
+        clone: () => ({
+          json: () => Promise.resolve(mockGroups),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const tenantId = 'tenant-id';
+      const identifiers = ['one'];
+      const jwtSubjects = ['two'];
+      const resp: SdkResponse<Group[]> = await management.group.loadAllGroupsForMember(
+        tenantId,
+        jwtSubjects,
+        identifiers,
+      );
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        apiPaths.group.loadAllGroupsForMember,
+        { tenantId, jwtSubjects, identifiers },
+        { token: 'key' },
+      );
+
+      expect(resp).toEqual({
+        code: 200,
+        ok: true,
+        response: httpResponse,
+        data: mockGroups,
+      });
+    });
+  });
+
+  describe('loadAllGroupMembers', () => {
+    it('should send the correct request and receive correct response', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => mockGroups,
+        clone: () => ({
+          json: () => Promise.resolve(mockGroups),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const tenantId = 'tenant-id';
+      const groupId = 'group-id';
+      const resp: SdkResponse<Group[]> = await management.group.loadAllGroupMembers(
+        tenantId,
+        groupId,
+      );
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        apiPaths.group.loadAllGroupMembers,
+        { tenantId, groupId },
+        { token: 'key' },
+      );
+
+      expect(resp).toEqual({
+        code: 200,
+        ok: true,
+        response: httpResponse,
+        data: mockGroups,
+      });
+    });
+  });
+});

--- a/lib/management/group.ts
+++ b/lib/management/group.ts
@@ -1,0 +1,33 @@
+import { SdkResponse, transformResponse } from '@descope/core-js-sdk';
+import { CoreSdk } from '../types';
+import apiPaths from './paths';
+import { Group } from './types';
+
+const withGroup = (sdk: CoreSdk, managementKey?: string) => ({
+  loadAllGroups: (tenantId: string): Promise<SdkResponse<Group[]>> =>
+    transformResponse<Group[]>(
+      sdk.httpClient.post(apiPaths.group.loadAllGroups, { tenantId }, { token: managementKey }),
+    ),
+  loadAllGroupsForMember: (
+    tenantId: string,
+    jwtSubjects: string[],
+    identifiers: string[],
+  ): Promise<SdkResponse<Group[]>> =>
+    transformResponse<Group[]>(
+      sdk.httpClient.post(
+        apiPaths.group.loadAllGroupsForMember,
+        { tenantId, identifiers, jwtSubjects },
+        { token: managementKey },
+      ),
+    ),
+  loadAllGroupMembers: (tenantId: string, groupId: string): Promise<SdkResponse<Group[]>> =>
+    transformResponse<Group[]>(
+      sdk.httpClient.post(
+        apiPaths.group.loadAllGroupMembers,
+        { tenantId, groupId },
+        { token: managementKey },
+      ),
+    ),
+});
+
+export default withGroup;

--- a/lib/management/group.ts
+++ b/lib/management/group.ts
@@ -4,10 +4,23 @@ import apiPaths from './paths';
 import { Group } from './types';
 
 const withGroup = (sdk: CoreSdk, managementKey?: string) => ({
+  /**
+   * Load all groups for a specific tenant id.
+   * @param tenantId Tenant ID to load groups from.
+   * @returns Group[] list of groups
+   */
   loadAllGroups: (tenantId: string): Promise<SdkResponse<Group[]>> =>
     transformResponse<Group[]>(
       sdk.httpClient.post(apiPaths.group.loadAllGroups, { tenantId }, { token: managementKey }),
     ),
+
+  /**
+   * Load all groups for the provided user JWT subjects or identifiers.
+   * @param tenantId Tenant ID to load groups from.
+   * @param jwtSubjects Optional List of JWT subjects, with the format of "U2J5ES9S8TkvCgOvcrkpzUgVTEBM" (example), which can be found on the user's JWT.
+   * @param identifiers Optional List of identifiers, identifier is the actual user identifier used for sign in.
+   * @returns Group[] list of groups
+   */
   loadAllGroupsForMember: (
     tenantId: string,
     jwtSubjects: string[],
@@ -20,6 +33,13 @@ const withGroup = (sdk: CoreSdk, managementKey?: string) => ({
         { token: managementKey },
       ),
     ),
+
+  /**
+   * Load all members of the provided group id.
+   * @param tenantId Tenant ID to load groups from.
+   * @param groupId Group ID to load members for.
+   * @returns Group[] list of groups
+   */
   loadAllGroupMembers: (tenantId: string, groupId: string): Promise<SdkResponse<Group[]>> =>
     transformResponse<Group[]>(
       sdk.httpClient.post(

--- a/lib/management/index.ts
+++ b/lib/management/index.ts
@@ -4,6 +4,7 @@ import withTenant from './tenant';
 import withJWT from './jwt';
 import withPermission from './permission';
 import withRole from './role';
+import withGroup from './group';
 import withSSOSettings from './sso';
 
 /** Constructs a higher level Management API that wraps the functions from code-js-sdk */
@@ -14,6 +15,7 @@ const withManagement = (sdk: CoreSdk, managementKey?: string) => ({
   jwt: withJWT(sdk, managementKey),
   permission: withPermission(sdk, managementKey),
   role: withRole(sdk, managementKey),
+  group: withGroup(sdk, managementKey),
 });
 
 export default withManagement;

--- a/lib/management/paths.ts
+++ b/lib/management/paths.ts
@@ -33,4 +33,9 @@ export default {
     delete: '/v1/mgmt/role/delete',
     loadAll: '/v1/mgmt/role/all',
   },
+  group: {
+    loadAllGroups: '/v1/mgmt/group/all',
+    loadAllGroupsForMember: '/v1/mgmt/group/member/all',
+    loadAllGroupMembers: '/v1/mgmt/group/members',
+  },
 };

--- a/lib/management/types.ts
+++ b/lib/management/types.ts
@@ -57,3 +57,17 @@ export type Role = {
   description?: string;
   permissionNames: string[];
 };
+
+/** Represents a group in a project. It has an id and display name and a list of group members. */
+export type Group = {
+  id: string;
+  display: string;
+  members?: GroupMember[];
+};
+
+/** Represents a group member. It has identifier, jwtSubject and display. */
+export type GroupMember = {
+  identifier: string;
+  jwtSubject: string;
+  display: string;
+};


### PR DESCRIPTION
## Description
Add group support for management sdk for a specific project's tenant.
- loadAllGroups `<tenantId>`
- loadAllGroupsForMember `<tenantId>, <jwtSubjects>, <identifiers>`
- loadAllGroupMembers `<tenantId>, <groupId>`

The above return list of groups include all members.

## Must
- [x] Tests
- [x] Documentation
