### PR TITLE
Add page to searchAll users

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ const userRes = await descopeClient.management.user.load('desmond@descope.com');
 const userRes = await descopeClient.management.user.loadByUserId('<user-ID>');
 
 // Search all users, optionally according to tenant and/or role filter
+// Results can be paginated using the limit and page parameters
 const usersRes = await descopeClient.management.user.searchAll(['tenant-ID']);
 usersRes.data.forEach((user) => {
   // do something

--- a/lib/management/user.ts
+++ b/lib/management/user.ts
@@ -70,15 +70,25 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => ({
       }),
       (data) => data.user,
     ),
+  /**
+   * Search all users. Results can be filtered according to tenants and/or
+   * roles, and also paginated used the limit and page parameters.
+   * @param tenantIds optional list of tenant IDs to filter by
+   * @param roles optional list of roles to filter by
+   * @param limit optionally limit the response, leave out for default limit
+   * @param page optionally paginate over the response
+   * @returns An array of UserResponse found by the query
+   */
   searchAll: (
     tenantIds?: string[],
     roles?: string[],
     limit?: number,
+    page?: number,
   ): Promise<SdkResponse<UserResponse[]>> =>
     transformResponse<MultipleUsersResponse, UserResponse[]>(
       sdk.httpClient.post(
         apiPaths.user.search,
-        { tenantIds, roleNames: roles, limit },
+        { tenantIds, roleNames: roles, limit, page },
         { token: managementKey },
       ),
       (data) => data.users,


### PR DESCRIPTION
## Description

Add the ability to paginate the search user response. If not explicitly set, `page` defaults to `0` (the first page).

## Must

- [X] Tests
- [X] Documentation (if applicable)
