### PR TITLE
Add support for test user

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,7 +682,7 @@ that way, you don't need to use 3rd party messaging services in order to receive
 ```typescript
 // User for test can be created, this user will be able to generate code/link without
 // the need of 3rd party messaging services.
-// Test user must have a loginID, other fields are optional.
+// Test user must have a loginId, other fields are optional.
 // Roles should be set directly if no tenants exist, otherwise set
 // on a per-tenant basis.
 await descopeClient.management.user.createTestUser(

--- a/README.md
+++ b/README.md
@@ -674,6 +674,55 @@ const updatedJWTRes = await descopeClient.management.jwt.update('original-jwt', 
 });
 ```
 
+### Utils for your end to end (e2e) tests and integration tests
+
+To ease your e2e tests, we exposed dedicated management methods,
+that way, you don't need to use 3rd party messaging services in order to receive sign-in/up Emails or SMS, and avoid the need of parsing the code and token from them.
+
+```typescript
+// User for test can be created, this user will be able to generate code/link without
+// the need of 3rd party messaging services.
+// Test user must have a loginID, other fields are optional.
+// Roles should be set directly if no tenants exist, otherwise set
+// on a per-tenant basis.
+await descopeClient.management.user.createTestUser(
+  'desmond@descope.com',
+  'desmond@descope.com',
+  null,
+  'Desmond Copeland',
+  null,
+  [{ tenantId: 'tenant-ID1', roleNames: ['role-name1'] }],
+);
+
+// Now test user got created, and this user will be available until you delete it,
+// you can use any management operation for test user CRUD.
+// You can also delete all test users.
+await descopeClient.management.user.deleteAllTestUsers();
+
+// OTP code can be generated for test user, for example:
+const { code } = await descopeClient.management.user.generateOTPForTestUser(
+  'sms',
+  'desmond@descope.com',
+);
+// Now you can verify the code is valid (using descopeClient.auth.*.verify for example)
+
+// Same as OTP, magic link can be generated for test user, for example:
+const { link } = await descopeClient.management.user.generateMagicLinkForTestUser(
+  'email',
+  'desmond@descope.com',
+  '',
+);
+
+// Enchanted link can be generated for test user, for example:
+const { link, pendingRef } = await descopeClient.management.user.generateEnchantedLinkForTestUser(
+  'desmond@descope.com',
+  '',
+);
+
+// Note 1: The generate code/link functions, work only for test users, will not work for regular users.
+// Note 2: In case of testing sign-in / sign-up operations with test users, need to make sure to generate the code prior calling the sign-in / sign-up operations.
+```
+
 ## Code Examples
 
 You can find various usage examples in the [examples folder](https://github.com/descope/node-sdk/blob/main/examples).

--- a/lib/management/paths.ts
+++ b/lib/management/paths.ts
@@ -4,6 +4,7 @@ export default {
     create: '/v1/mgmt/user/create',
     update: '/v1/mgmt/user/update',
     delete: '/v1/mgmt/user/delete',
+    deleteAllTestUsers: '/v1/mgmt/user/test/delete/all',
     load: '/v1/mgmt/user',
     search: '/v1/mgmt/user/search',
     updateStatus: '/v1/mgmt/user/update/status',
@@ -14,6 +15,9 @@ export default {
     removeRole: '/v1/mgmt/user/update/role/remove',
     addTenant: '/v1/mgmt/user/update/tenant/add',
     removeTenant: '/v1/mgmt/user/update/tenant/remove',
+    generateOTPForTest: '/v1/mgmt/tests/generate/otp',
+    generateMagicLinkForTest: '/v1/mgmt/tests/generate/magiclink',
+    generateEnchantedLinkForTest: '/v1/mgmt/tests/generate/enchantedlink',
   },
   accessKey: {
     create: '/v1/mgmt/accesskey/create',

--- a/lib/management/types.ts
+++ b/lib/management/types.ts
@@ -121,3 +121,19 @@ export type Theme = {
 export type ThemeResponse = {
   theme: Theme;
 };
+
+export type GenerateOTPForTestResponse = {
+  loginId: string;
+  code: string;
+};
+
+export type GenerateMagicLinkForTestResponse = {
+  loginId: string;
+  link: string;
+};
+
+export type GenerateEnchantedLinkForTestResponse = {
+  loginId: string;
+  link: string;
+  pendingRef: string;
+};

--- a/lib/management/user.test.ts
+++ b/lib/management/user.test.ts
@@ -2,6 +2,11 @@ import { SdkResponse, UserResponse } from '@descope/core-js-sdk';
 import withManagement from '.';
 import apiPaths from './paths';
 import { mockCoreSdk, mockHttpClient } from './testutils';
+import {
+  GenerateOTPForTestResponse,
+  GenerateMagicLinkForTestResponse,
+  GenerateEnchantedLinkForTestResponse,
+} from './types';
 
 const management = withManagement(mockCoreSdk, 'key');
 
@@ -51,6 +56,48 @@ describe('Management User', () => {
           phone: null,
           displayName: null,
           roleNames: ['r1', 'r2'],
+        },
+        { token: 'key' },
+      );
+
+      expect(resp).toEqual({
+        code: 200,
+        data: mockUserResponse,
+        ok: true,
+        response: httpResponse,
+      });
+    });
+  });
+
+  describe('createTestUser', () => {
+    it('should send the correct request and receive correct response', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => mockMgmtUserResponse,
+        clone: () => ({
+          json: () => Promise.resolve(mockMgmtUserResponse),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const resp: SdkResponse<UserResponse> = await management.user.createTestUser(
+        'loginId',
+        'a@b.c',
+        null,
+        null,
+        ['r1', 'r2'],
+      );
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        apiPaths.user.create,
+        {
+          loginId: 'loginId',
+          email: 'a@b.c',
+          phone: null,
+          displayName: null,
+          roleNames: ['r1', 'r2'],
+          test: true,
         },
         { token: 'key' },
       );
@@ -152,6 +199,35 @@ describe('Management User', () => {
       expect(mockHttpClient.post).toHaveBeenCalledWith(
         apiPaths.user.delete,
         { loginId: 'loginId' },
+        { token: 'key' },
+      );
+
+      expect(resp).toEqual({
+        code: 200,
+        data: {},
+        ok: true,
+        response: httpResponse,
+      });
+    });
+  });
+
+  describe('deleteAllTestUsers', () => {
+    it('should send the correct request and receive correct response', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => {},
+        clone: () => ({
+          json: () => Promise.resolve({}),
+        }),
+        status: 200,
+      };
+      mockHttpClient.delete.mockResolvedValue(httpResponse);
+
+      const resp: SdkResponse<never> = await management.user.deleteAllTestUsers();
+
+      expect(mockHttpClient.delete).toHaveBeenCalledWith(
+        apiPaths.user.deleteAllTestUsers,
+        {},
         { token: 'key' },
       );
 
@@ -584,6 +660,103 @@ describe('Management User', () => {
       expect(resp).toEqual({
         code: 200,
         data: mockUserResponse,
+        ok: true,
+        response: httpResponse,
+      });
+    });
+  });
+
+  describe('generateOTPForTestUser', () => {
+    it('should send the correct request and receive correct response', async () => {
+      const mockResponse = { loginId: 'some-id', code: '123456' };
+      const httpResponse = {
+        ok: true,
+        json: () => mockResponse,
+        clone: () => ({
+          json: () => Promise.resolve(mockResponse),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const resp: SdkResponse<GenerateOTPForTestResponse> =
+        await management.user.generateOTPForTestUser('sms', 'some-id');
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        apiPaths.user.generateOTPForTest,
+        { loginId: 'some-id', deliveryMethod: 'sms' },
+        { token: 'key' },
+      );
+
+      expect(resp).toEqual({
+        code: 200,
+        data: mockResponse,
+        ok: true,
+        response: httpResponse,
+      });
+    });
+  });
+
+  describe('generateMagicLinkForTestUser', () => {
+    it('should send the correct request and receive correct response', async () => {
+      const mockResponse = { loginId: 'some-id', link: 'some-link' };
+      const httpResponse = {
+        ok: true,
+        json: () => mockResponse,
+        clone: () => ({
+          json: () => Promise.resolve(mockResponse),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const resp: SdkResponse<GenerateMagicLinkForTestResponse> =
+        await management.user.generateMagicLinkForTestUser('email', 'some-id', 'some-uri');
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        apiPaths.user.generateMagicLinkForTest,
+        { loginId: 'some-id', deliveryMethod: 'email', URI: 'some-uri' },
+        { token: 'key' },
+      );
+
+      expect(resp).toEqual({
+        code: 200,
+        data: mockResponse,
+        ok: true,
+        response: httpResponse,
+      });
+    });
+  });
+
+  describe('generateEnchantedLinkForTestUser', () => {
+    it('should send the correct request and receive correct response', async () => {
+      const mockResponse = {
+        loginId: 'some-id',
+        link: 'some-link',
+        pendingRef: 'some-pending-ref',
+      };
+      const httpResponse = {
+        ok: true,
+        json: () => mockResponse,
+        clone: () => ({
+          json: () => Promise.resolve(mockResponse),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const resp: SdkResponse<GenerateEnchantedLinkForTestResponse> =
+        await management.user.generateEnchantedLinkForTestUser('some-id', 'some-uri');
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        apiPaths.user.generateEnchantedLinkForTest,
+        { loginId: 'some-id', URI: 'some-uri' },
+        { token: 'key' },
+      );
+
+      expect(resp).toEqual({
+        code: 200,
+        data: mockResponse,
         ok: true,
         response: httpResponse,
       });

--- a/lib/management/user.ts
+++ b/lib/management/user.ts
@@ -1,7 +1,12 @@
-import { SdkResponse, transformResponse, UserResponse } from '@descope/core-js-sdk';
+import { DeliveryMethod, SdkResponse, transformResponse, UserResponse } from '@descope/core-js-sdk';
 import { CoreSdk } from '../types';
 import apiPaths from './paths';
-import { AssociatedTenant } from './types';
+import {
+  AssociatedTenant,
+  GenerateEnchantedLinkForTestResponse,
+  GenerateMagicLinkForTestResponse,
+  GenerateOTPForTestResponse,
+} from './types';
 
 type SingleUserResponse = {
   user: UserResponse;
@@ -24,6 +29,32 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => ({
       sdk.httpClient.post(
         apiPaths.user.create,
         { loginId, email, phone, displayName, roleNames: roles, userTenants },
+        { token: managementKey },
+      ),
+      (data) => data.user,
+    ),
+  /**
+   * Create a new test user.
+   * The loginID is required and will determine what the user will use to sign in.
+   * Make sure the login id is unique for test. All other fields are optional.
+   *
+   * You can later generate OTP, Magic link and enchanted link to use in the test without the need
+   * of 3rd party messaging services.
+   * Those users are not counted as part of the monthly active users
+   * @returns The UserResponse if found, throws otherwise.
+   */
+  createTestUser: (
+    loginId: string,
+    email?: string,
+    phone?: string,
+    displayName?: string,
+    roles?: string[],
+    userTenants?: AssociatedTenant[],
+  ): Promise<SdkResponse<UserResponse>> =>
+    transformResponse<SingleUserResponse, UserResponse>(
+      sdk.httpClient.post(
+        apiPaths.user.create,
+        { loginId, email, phone, displayName, roleNames: roles, userTenants, test: true },
         { token: managementKey },
       ),
       (data) => data.user,
@@ -64,6 +95,13 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => ({
     transformResponse(
       sdk.httpClient.post(apiPaths.user.delete, { loginId }, { token: managementKey }),
     ),
+  /**
+   * Delete all test users in the project.
+   */
+  deleteAllTestUsers: (): Promise<SdkResponse<never>> =>
+    transformResponse(
+      sdk.httpClient.delete(apiPaths.user.deleteAllTestUsers, {}, { token: managementKey }),
+    ),
   load: (loginId: string): Promise<SdkResponse<UserResponse>> =>
     transformResponse<SingleUserResponse, UserResponse>(
       sdk.httpClient.get(apiPaths.user.load, {
@@ -93,6 +131,8 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => ({
    * @param roles optional list of roles to filter by
    * @param limit optionally limit the response, leave out for default limit
    * @param page optionally paginate over the response
+   * @param testUsersOnly optionally filter only test users
+   * @param withTestUser optionally include test users in search
    * @returns An array of UserResponse found by the query
    */
   searchAll: (
@@ -100,11 +140,13 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => ({
     roles?: string[],
     limit?: number,
     page?: number,
+    testUsersOnly?: boolean,
+    withTestUser?: boolean,
   ): Promise<SdkResponse<UserResponse[]>> =>
     transformResponse<MultipleUsersResponse, UserResponse[]>(
       sdk.httpClient.post(
         apiPaths.user.search,
-        { tenantIds, roleNames: roles, limit, page },
+        { tenantIds, roleNames: roles, limit, page, testUsersOnly, withTestUser },
         { token: managementKey },
       ),
       (data) => data.users,
@@ -219,6 +261,77 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => ({
         { token: managementKey },
       ),
       (data) => data.user,
+    ),
+
+  /**
+   * Generate OTP for the given login ID of a test user.
+   * Choose the selected delivery method for verification.
+   * Returns the code for the login (exactly as it sent via Email or SMS)
+   * This is useful when running tests and don't want to use 3rd party messaging services
+   *
+   * @param deliveryMethod optional DeliveryMethod
+   * @param loginId login ID of a test user
+   * @returns GenerateOTPForTestResponse which includes the loginId and the OTP code
+   */
+  generateOTPForTestUser: (
+    deliveryMethod: DeliveryMethod,
+    loginId: string,
+  ): Promise<SdkResponse<GenerateOTPForTestResponse>> =>
+    transformResponse<GenerateOTPForTestResponse>(
+      sdk.httpClient.post(
+        apiPaths.user.generateOTPForTest,
+        { deliveryMethod, loginId },
+        { token: managementKey },
+      ),
+      (data) => data,
+    ),
+
+  /**
+   * Generate Magic Link for the given login ID of a test user.
+   * Choose the selected delivery method for verification.
+   * It returns the link for the login (exactly as it sent via Email)
+   * This is useful when running tests and don't want to use 3rd party messaging services
+   *
+   * @param deliveryMethod optional DeliveryMethod
+   * @param loginId login ID of a test user
+   * @param uri optional redirect uri which will be used instead of any global configuration.
+   * @returns GenerateOTPForTestResponse which includes the loginId and the OTP code
+   */
+  generateMagicLinkForTestUser: (
+    deliveryMethod: DeliveryMethod,
+    loginId: string,
+    uri: string,
+  ): Promise<SdkResponse<GenerateMagicLinkForTestResponse>> =>
+    transformResponse<GenerateMagicLinkForTestResponse>(
+      sdk.httpClient.post(
+        apiPaths.user.generateMagicLinkForTest,
+        { deliveryMethod, loginId, URI: uri },
+        { token: managementKey },
+      ),
+      (data) => data,
+    ),
+
+  /**
+   * Generate Enchanted Link for the given login ID of a test user.
+   * It returns the link for the login (exactly as it sent via Email)
+   * and pendingRef which is used to poll for a valid session
+   * This is useful when running tests and don't want to use 3rd party messaging services
+   *
+   * @param loginId login ID of a test user
+   * @param uri optional redirect uri which will be used instead of any global configuration.
+   * @returns GenerateOTPForTestResponse which includes the loginId and the OTP code
+   */
+  generateEnchantedLinkForTestUser: (
+    loginId: string,
+    uri: string,
+  ): Promise<SdkResponse<GenerateEnchantedLinkForTestResponse>> =>
+    transformResponse<GenerateEnchantedLinkForTestResponse>(
+      sdk.httpClient.post(
+        apiPaths.user.generateEnchantedLinkForTest,
+        { loginId, URI: uri },
+        { token: managementKey },
+      ),
+      (data) => data,
     ),
 });
 


### PR DESCRIPTION
## Description
Add support for test user:
- Create user for test
- Delete all test users
- Generate access (code and link) for test user

Related to: https://github.com/descope/etc/issues/1918

## Must
- [x] Tests
- [x] Documentation
