### PR TITLE
align high watermark bytes

### DIFF
--- a/lib/fetch-polyfill.ts
+++ b/lib/fetch-polyfill.ts
@@ -2,7 +2,7 @@ import nodeFetch, { Headers } from 'node-fetch-commonjs';
 
 globalThis.Headers ??= Headers;
 
-const highWaterMarkMb = 1024 * 1024 * 1024 * 30; // 30MB
+const highWaterMarkMb = 1024 * 1024 * 30; // 30MB
 
 // we are increasing the response buffer size due to an issue where node-fetch hangs when response is too big
 const patchedFetch = (...args: Parameters<typeof nodeFetch>) => {


### PR DESCRIPTION
## Description
aligning request high watermark to 30 MB instead 30 GB


![image](https://user-images.githubusercontent.com/10514677/232149789-076e13ca-d4b6-492d-b986-5030a327d1dd.png)

