### PR TITLE
Support custom attributes for user management SDK

### DIFF
--- a/lib/management/role.test.ts
+++ b/lib/management/role.test.ts
@@ -7,9 +7,24 @@ import { Role } from './types';
 const management = withManagement(mockCoreSdk, 'key');
 
 const mockRoles = [
-  { name: 'name', description: 'description', permissionNames: ['p1', 'p2'] },
-  { name: 'name2', description: 'description2', permissionNames: ['p1'] },
-  { name: 'name3', description: 'description3', permissionNames: [] },
+  {
+    name: 'name',
+    description: 'description',
+    permissionNames: ['p1', 'p2'],
+    createdTime: new Date().getTime(),
+  },
+  {
+    name: 'name2',
+    description: 'description2',
+    permissionNames: ['p1'],
+    createdTime: new Date().getTime(),
+  },
+  {
+    name: 'name3',
+    description: 'description3',
+    permissionNames: [],
+    createdTime: new Date().getTime(),
+  },
 ];
 
 const mockAllRolesResponse = {

--- a/lib/management/types.ts
+++ b/lib/management/types.ts
@@ -75,6 +75,7 @@ export type Role = {
   name: string;
   description?: string;
   permissionNames: string[];
+  createdTime: number;
 };
 
 /** Represents a group in a project. It has an id and display name and a list of group members. */
@@ -137,3 +138,5 @@ export type GenerateEnchantedLinkForTestResponse = {
   link: string;
   pendingRef: string;
 };
+
+export type AttributesTypes = string | boolean | number;

--- a/lib/management/user.test.ts
+++ b/lib/management/user.test.ts
@@ -46,6 +46,8 @@ describe('Management User', () => {
         null,
         null,
         ['r1', 'r2'],
+        null,
+        { a: 'a', b: 1, c: true },
       );
 
       expect(mockHttpClient.post).toHaveBeenCalledWith(
@@ -56,6 +58,8 @@ describe('Management User', () => {
           phone: null,
           displayName: null,
           roleNames: ['r1', 'r2'],
+          userTenants: null,
+          customAttributes: { a: 'a', b: 1, c: true },
         },
         { token: 'key' },
       );
@@ -87,6 +91,8 @@ describe('Management User', () => {
         null,
         null,
         ['r1', 'r2'],
+        null,
+        { a: 'a', b: 1, c: true },
       );
 
       expect(mockHttpClient.post).toHaveBeenCalledWith(
@@ -98,6 +104,8 @@ describe('Management User', () => {
           displayName: null,
           roleNames: ['r1', 'r2'],
           test: true,
+          userTenants: null,
+          customAttributes: { a: 'a', b: 1, c: true },
         },
         { token: 'key' },
       );
@@ -129,6 +137,8 @@ describe('Management User', () => {
         null,
         null,
         ['r1', 'r2'],
+        null,
+        { a: 'a', b: 1, c: true },
       );
 
       expect(mockHttpClient.post).toHaveBeenCalledWith(
@@ -140,6 +150,8 @@ describe('Management User', () => {
           displayName: null,
           roleNames: ['r1', 'r2'],
           invite: true,
+          userTenants: null,
+          customAttributes: { a: 'a', b: 1, c: true },
         },
         { token: 'key' },
       );

--- a/lib/management/user.ts
+++ b/lib/management/user.ts
@@ -6,6 +6,7 @@ import {
   GenerateEnchantedLinkForTestResponse,
   GenerateMagicLinkForTestResponse,
   GenerateOTPForTestResponse,
+  AttributesTypes,
 } from './types';
 
 type SingleUserResponse = {
@@ -24,11 +25,12 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => ({
     displayName?: string,
     roles?: string[],
     userTenants?: AssociatedTenant[],
+    customAttributes?: Record<string, AttributesTypes>,
   ): Promise<SdkResponse<UserResponse>> =>
     transformResponse<SingleUserResponse, UserResponse>(
       sdk.httpClient.post(
         apiPaths.user.create,
-        { loginId, email, phone, displayName, roleNames: roles, userTenants },
+        { loginId, email, phone, displayName, roleNames: roles, userTenants, customAttributes },
         { token: managementKey },
       ),
       (data) => data.user,
@@ -50,11 +52,21 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => ({
     displayName?: string,
     roles?: string[],
     userTenants?: AssociatedTenant[],
+    customAttributes?: Record<string, AttributesTypes>,
   ): Promise<SdkResponse<UserResponse>> =>
     transformResponse<SingleUserResponse, UserResponse>(
       sdk.httpClient.post(
         apiPaths.user.create,
-        { loginId, email, phone, displayName, roleNames: roles, userTenants, test: true },
+        {
+          loginId,
+          email,
+          phone,
+          displayName,
+          roleNames: roles,
+          userTenants,
+          test: true,
+          customAttributes,
+        },
         { token: managementKey },
       ),
       (data) => data.user,
@@ -66,11 +78,21 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => ({
     displayName?: string,
     roles?: string[],
     userTenants?: AssociatedTenant[],
+    customAttributes?: Record<string, AttributesTypes>,
   ): Promise<SdkResponse<UserResponse>> =>
     transformResponse<SingleUserResponse, UserResponse>(
       sdk.httpClient.post(
         apiPaths.user.create,
-        { loginId, email, phone, displayName, roleNames: roles, userTenants, invite: true },
+        {
+          loginId,
+          email,
+          phone,
+          displayName,
+          roleNames: roles,
+          userTenants,
+          invite: true,
+          customAttributes,
+        },
         { token: managementKey },
       ),
       (data) => data.user,
@@ -82,11 +104,12 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => ({
     displayName?: string,
     roles?: string[],
     userTenants?: AssociatedTenant[],
+    customAttributes?: Record<string, AttributesTypes>,
   ): Promise<SdkResponse<UserResponse>> =>
     transformResponse<SingleUserResponse, UserResponse>(
       sdk.httpClient.post(
         apiPaths.user.update,
-        { loginId, email, phone, displayName, roleNames: roles, userTenants },
+        { loginId, email, phone, displayName, roleNames: roles, userTenants, customAttributes },
         { token: managementKey },
       ),
       (data) => data.user,


### PR DESCRIPTION
So one can now create/update/invite a user and have the custom attributes already in place
Assuming those were configured already in the Descope console
Export the user and role createTime
related to https://github.com/descope/etc/issues/2450
related to https://github.com/descope/etc/issues/299

