### PR TITLE
Check associated tenant

### DIFF
--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -65,7 +65,7 @@ export const withCookie: SdkFnWrapper<{ refreshJwt?: string; cookies?: string[] 
  * @param authInfo The parsed authentication info from the JWT
  * @param claim name of the claim
  * @param tenant tenant to retrieve the claim for
- * @returns
+ * @returns the claim for the given tenant or top level if tenant is empty
  */
 export function getAuthorizationClaimItems(
   authInfo: AuthenticationInfo,
@@ -76,4 +76,14 @@ export function getAuthorizationClaimItems(
     ? authInfo.token[authorizedTenantsClaimName]?.[tenant]?.[claim]
     : authInfo.token[claim];
   return Array.isArray(value) ? value : [];
+}
+
+/**
+ * Check if the user is associated with the given tenant
+ * @param authInfo The parsed authentication info from the JWT
+ * @param tenant tenant to check if user is associated with
+ * @returns true if user is associated with the tenant
+ */
+export function isUserAssociatedWithTenant(authInfo: AuthenticationInfo, tenant: string): boolean {
+  return !!authInfo.token[authorizedTenantsClaimName]?.[tenant];
 }

--- a/lib/index.test.ts
+++ b/lib/index.test.ts
@@ -70,6 +70,7 @@ describe('sdk', () => {
       token: {
         [authorizedTenantsClaimName]: {
           kuku: { [permissionsClaimName]: ['foo', 'bar'], [rolesClaimName]: ['abc', 'xyz'] },
+          t1: {},
         },
       },
     };
@@ -307,6 +308,8 @@ describe('sdk', () => {
       expect(sdk.validateTenantRoles(permTenantAuthInfo, 'kuku', ['abc', 'xyz'])).toStrictEqual(
         true,
       );
+      expect(sdk.validateTenantRoles(permTenantAuthInfo, 't1', [])).toStrictEqual(true);
+      expect(sdk.validateTenantPermissions(permTenantAuthInfo, 't1', [])).toStrictEqual(true);
     });
     it('should fail when wrong function is used', () => {
       expect(sdk.validatePermissions(permTenantAuthInfo, ['foo'])).toStrictEqual(false);
@@ -323,6 +326,8 @@ describe('sdk', () => {
       expect(
         sdk.validateTenantRoles(permTenantAuthInfo, 'kuku', ['abc', 'xyz', 'tuv']),
       ).toStrictEqual(false);
+      expect(sdk.validateTenantRoles(permTenantAuthInfo, 't2', [])).toStrictEqual(false);
+      expect(sdk.validateTenantPermissions(permTenantAuthInfo, 't2', [])).toStrictEqual(false);
     });
   });
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -6,7 +6,7 @@ import {
   rolesClaimName,
   sessionTokenCookieName,
 } from './constants';
-import { getAuthorizationClaimItems, withCookie } from './helpers';
+import { getAuthorizationClaimItems, isUserAssociatedWithTenant, withCookie } from './helpers';
 import withManagement from './management';
 import { AuthenticationInfo } from './types';
 import fetch from './fetch-polyfill';
@@ -233,6 +233,9 @@ const nodeSdk = ({ managementKey, publicKey, ...config }: NodeSdkArgs) => {
       tenant: string,
       permissions: string[],
     ): boolean {
+      // check if user is associated to the tenant
+      if (tenant && !isUserAssociatedWithTenant(authInfo, tenant)) return false;
+
       const granted = getAuthorizationClaimItems(authInfo, permissionsClaimName, tenant);
       return permissions.every((perm) => granted.includes(perm));
     },
@@ -254,6 +257,9 @@ const nodeSdk = ({ managementKey, publicKey, ...config }: NodeSdkArgs) => {
      * @returns true if all roles exist, false otherwise
      */
     validateTenantRoles(authInfo: AuthenticationInfo, tenant: string, roles: string[]): boolean {
+      // check if user is associated to the tenant
+      if (tenant && !isUserAssociatedWithTenant(authInfo, tenant)) return false;
+
       const membership = getAuthorizationClaimItems(authInfo, rolesClaimName, tenant);
       return roles.every((role) => membership.includes(role));
     },


### PR DESCRIPTION
## Related Issues

https://github.com/descope/etc/issues/3104

## Description
Ensure that the user 
assuming `user1` with `authInfo1` belongs to `t1` with `r1` and `p1`
```
// with empty values
sdk.validateTenantRoles(authInfo1, 't1', []) === true // as before
sdk.validateTenantPermissions(authInfo1, 't1', []) === true // as before

// with role/tenant values
sdk.validateTenantRoles(authInfo1, 't1', ['r1']) === true // as before
sdk.validateTenantPermissions(authInfo1, 't1', ['p1']) === true // as before

// with different tenant
sdk.validateTenantRoles(authInfo1, 't2', ['r1']) === false // as before
sdk.validateTenantPermissions(authInfo1, 't2', ['p1']) === false // as before

// with different tenant
sdk.validateTenantRoles(authInfo1, 't2', ['r1']) === false // as before
sdk.validateTenantPermissions(authInfo1, '21', ['p1']) === false // as before
sdk.validateTenantPermissions(authInfo1, 't2', []) === false // NOT as before
```

@dorsha lets talk about this change
