### PR TITLE
add filter to undefined properties before sending to SDK-CORE

### DIFF
--- a/lib/management/user.ts
+++ b/lib/management/user.ts
@@ -123,26 +123,30 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => ({
     picture?: string,
     verifiedEmail?: boolean,
     verifiedPhone?: boolean,
-  ): Promise<SdkResponse<UserResponse>> =>
-    transformResponse<SingleUserResponse, UserResponse>(
-      sdk.httpClient.post(
-        apiPaths.user.update,
-        {
-          loginId,
-          email,
-          phone,
-          displayName,
-          roleNames: roles,
-          userTenants,
-          customAttributes,
-          picture,
-          verifiedEmail,
-          verifiedPhone,
-        },
-        { token: managementKey },
-      ),
+  ): Promise<SdkResponse<UserResponse>> => {
+    const args = {
+      loginId,
+      email,
+      phone,
+      displayName,
+      roleNames: roles,
+      userTenants,
+      customAttributes,
+      picture,
+      verifiedEmail,
+      verifiedPhone,
+    };
+    const filtered = Object.entries(args).reduce((acc, [key, value]) => {
+      if (typeof value !== 'undefined') {
+        acc[key] = value;
+      }
+      return acc;
+    }, {});
+    return transformResponse<SingleUserResponse, UserResponse>(
+      sdk.httpClient.post(apiPaths.user.update, filtered, { token: managementKey }),
       (data) => data.user,
-    ),
+    );
+  },
   delete: (loginId: string): Promise<SdkResponse<never>> =>
     transformResponse(
       sdk.httpClient.post(apiPaths.user.delete, { loginId }, { token: managementKey }),


### PR DESCRIPTION
## Related Issues

Possibly Fixes #228
Just a Suggestion PR

## Description

Make it possible to update just one property of a User without having to fullfil all parameters in order

## Must

- [ ] Tests
- [ ] Documentation (if applicable)

## Known Issues
- It wont let update a property to undefined values
- Needs further testing that wasn't made since core-js-sdk isn't public
- It's not yet a batch update, better way was to change the function signature (needs further validation on prod impacts)
