### PR TITLE
Support domain and redirectURL field when updating SSO metadata URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,7 +632,7 @@ const domain = 'tenant-users.com' // Users authentication with this domain will 
 await descopeClient.management.sso.configureSettings(tenantID, idpURL, entityID, idpCert, redirectURL, domain)
 
 // Alternatively, configure using an SSO metadata URL
-await descopeClient.management.sso.configureMetadata(tenantID, 'https://idp.com/my-idp-metadata')
+await descopeClient.management.sso.configureMetadata(tenantID, 'https://idp.com/my-idp-metadata', redirectURL, domain)
 
 // Map IDP groups to Descope roles, or map user attributes.
 // This function overrides any previous mapping (even when empty). Use carefully.

--- a/lib/management/sso.test.ts
+++ b/lib/management/sso.test.ts
@@ -126,13 +126,22 @@ describe('Management SSO', () => {
 
       const tenantId = 't1';
       const idpMetadataURL = 'https://idp.com';
-      const resp = await management.sso.configureMetadata(tenantId, idpMetadataURL);
+      const redirectURL = 'https://redirect.com';
+      const domain = 'domain.com';
+      const resp = await management.sso.configureMetadata(
+        tenantId,
+        idpMetadataURL,
+        redirectURL,
+        domain,
+      );
 
       expect(mockHttpClient.post).toHaveBeenCalledWith(
         apiPaths.sso.metadata,
         {
           tenantId,
           idpMetadataURL,
+          domain,
+          redirectURL,
         },
         { token: 'key' },
       );

--- a/lib/management/sso.ts
+++ b/lib/management/sso.ts
@@ -24,8 +24,8 @@ const withSSOSettings = (sdk: CoreSdk, managementKey?: string) => ({
     idpURL: string,
     idpCert: string,
     entityId: string,
-    redirectURL?: string,
-    domain?: string,
+    redirectURL: string,
+    domain: string,
   ): Promise<SdkResponse<never>> =>
     transformResponse(
       sdk.httpClient.post(

--- a/lib/management/sso.ts
+++ b/lib/management/sso.ts
@@ -34,11 +34,16 @@ const withSSOSettings = (sdk: CoreSdk, managementKey?: string) => ({
         { token: managementKey },
       ),
     ),
-  configureMetadata: (tenantId: string, idpMetadataURL: string): Promise<SdkResponse<never>> =>
+  configureMetadata: (
+    tenantId: string,
+    idpMetadataURL: string,
+    redirectURL: string,
+    domain: string,
+  ): Promise<SdkResponse<never>> =>
     transformResponse(
       sdk.httpClient.post(
         apiPaths.sso.metadata,
-        { tenantId, idpMetadataURL },
+        { tenantId, idpMetadataURL, redirectURL, domain },
         { token: managementKey },
       ),
     ),


### PR DESCRIPTION
## Description
- Adds the missing `redirectUrl` and `domain` parameters to the `management.sso.configureMetadata` function.
- The types of the current `redirectUrl` and `domain` parameters are now `string` rather than `string?` in both `configureMetadata` and `configureSettings` functions.
- When calling either functions you can either pass a valid `redirectURL` / `domain` as the parameter value, or an empty `string` to reset whatever's currently set.

## Impact
- Callers that are not using TypeScript shouldn't experience any difference in behavior.
- This is a minor **_BREAKING CHANGE_** in that TypeScript might complain about the following during compilation:
    - Existing calls to `configureMetadata` will miss the two new parameters – pass a `string` value for them as explained above.
    - Existing calls to `configureSettings` might have passed a `null` value in some cases – pass an empty `string` instead of `null` to keep the same behavior.

## Must
- [X] Tests
- [X] Documentation (if applicable)
