### PR TITLE
allow override fetch

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -21,8 +21,8 @@ type NodeSdkArgs = Parameters<typeof createSdk>[0] & {
 
 const nodeSdk = ({ managementKey, publicKey, ...config }: NodeSdkArgs) => {
   const coreSdk = createSdk({
-    ...config,
     fetch,
+    ...config,
     baseHeaders: {
       ...config.baseHeaders,
       'x-descope-sdk-name': 'nodejs',


### PR DESCRIPTION
## Related Issues

https://github.com/descope/etc/issues/2300

## Description
allow override fetch (default is `node-fetch-commonjs`)

this will allow to use node-sdk in an edge-like environments 