### PR TITLE
add support for authz APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Then, you can use that to work with the following functions:
 9. [Manage JWTs](#manage-jwts)
 10. [Embedded Links](#embedded-links)
 11. [Search Audit](#search-audit)
+12. [Manage Authz](#manage-authz)
 
 If you wish to run any of our code samples and play with them, check out our [Code Examples](#code-examples) section.
 
@@ -838,6 +839,185 @@ console.log(audits);
 // Search successful logins in the last 30 days
 const audits = await descopeClient.management.audit.search({ actions: ['LoginSucceed'] });
 console.log(audits);
+```
+
+### Manage Authz
+
+Descope support full relation based access control (ReBAC) using a zanzibar like schema and operations.
+A schema is comprized of namespaces (entities like documents, folders, orgs, etc.) and each namespace has relation definitions to define relations.
+Each relation definition can be simple (either you have it or not) or complex (union of nodes).
+
+A simple example for a file system like schema would be:
+
+```yaml
+# Example schema for the authz tests
+name: Files
+namespaces:
+  - name: org
+    relationDefinitions:
+      - name: parent
+      - name: member
+        complexDefinition:
+          nType: union
+          children:
+            - nType: child
+              expression:
+                neType: self
+            - nType: child
+              expression:
+                neType: relationLeft
+                relationDefinition: parent
+                relationDefinitionNamespace: org
+                targetRelationDefinition: member
+                targetRelationDefinitionNamespace: org
+  - name: folder
+    relationDefinitions:
+      - name: parent
+      - name: owner
+        complexDefinition:
+          nType: union
+          children:
+            - nType: child
+              expression:
+                neType: self
+            - nType: child
+              expression:
+                neType: relationRight
+                relationDefinition: parent
+                relationDefinitionNamespace: folder
+                targetRelationDefinition: owner
+                targetRelationDefinitionNamespace: folder
+      - name: editor
+        complexDefinition:
+          nType: union
+          children:
+            - nType: child
+              expression:
+                neType: self
+            - nType: child
+              expression:
+                neType: relationRight
+                relationDefinition: parent
+                relationDefinitionNamespace: folder
+                targetRelationDefinition: editor
+                targetRelationDefinitionNamespace: folder
+            - nType: child
+              expression:
+                neType: targetSet
+                targetRelationDefinition: owner
+                targetRelationDefinitionNamespace: folder
+      - name: viewer
+        complexDefinition:
+          nType: union
+          children:
+            - nType: child
+              expression:
+                neType: self
+            - nType: child
+              expression:
+                neType: relationRight
+                relationDefinition: parent
+                relationDefinitionNamespace: folder
+                targetRelationDefinition: viewer
+                targetRelationDefinitionNamespace: folder
+            - nType: child
+              expression:
+                neType: targetSet
+                targetRelationDefinition: editor
+                targetRelationDefinitionNamespace: folder
+  - name: doc
+    relationDefinitions:
+      - name: parent
+      - name: owner
+        complexDefinition:
+          nType: union
+          children:
+            - nType: child
+              expression:
+                neType: self
+            - nType: child
+              expression:
+                neType: relationRight
+                relationDefinition: parent
+                relationDefinitionNamespace: doc
+                targetRelationDefinition: owner
+                targetRelationDefinitionNamespace: folder
+      - name: editor
+        complexDefinition:
+          nType: union
+          children:
+            - nType: child
+              expression:
+                neType: self
+            - nType: child
+              expression:
+                neType: relationRight
+                relationDefinition: parent
+                relationDefinitionNamespace: doc
+                targetRelationDefinition: editor
+                targetRelationDefinitionNamespace: folder
+            - nType: child
+              expression:
+                neType: targetSet
+                targetRelationDefinition: owner
+                targetRelationDefinitionNamespace: doc
+      - name: viewer
+        complexDefinition:
+          nType: union
+          children:
+            - nType: child
+              expression:
+                neType: self
+            - nType: child
+              expression:
+                neType: relationRight
+                relationDefinition: parent
+                relationDefinitionNamespace: doc
+                targetRelationDefinition: viewer
+                targetRelationDefinitionNamespace: folder
+            - nType: child
+              expression:
+                neType: targetSet
+                targetRelationDefinition: editor
+                targetRelationDefinitionNamespace: doc
+```
+
+Descope SDK allows you to fully manage the schema and relations as well as perform simple (and not so simple) checks regarding the existence of relations.
+
+```typescript
+// Load the existing schema
+const s = await descopeClient.management.authz.loadSchema();
+console.log(s);
+
+// Save schema and make sure to remove all namespaces not listed
+await descopeClient.management.authz.saveSchema(s, true);
+
+// Create a relation between a resource and user
+await descopeClient.management.authz.createRelations([
+  {
+    resource: 'some-doc',
+    relationDefinition: 'owner',
+    namespace: 'doc',
+    target: 'u1',
+  },
+  {
+    resource: 'some-doc',
+    relationDefinition: 'editor',
+    namespace: 'doc',
+    target: 'u2',
+  },
+]);
+
+// Check if target has the relevant relation
+// The answer should be true because an owner is also a viewer
+const q = await descopeClient.management.authz.hasRelations([
+  {
+    resource: 'some-doc',
+    relationDefinition: 'viewer',
+    namespace: 'doc',
+    target: 'u1',
+  },
+]);
 ```
 
 ### Utils for your end to end (e2e) tests and integration tests

--- a/examples/managementCli/package-lock.json
+++ b/examples/managementCli/package-lock.json
@@ -24,12 +24,12 @@
     },
     "../..": {
       "name": "@descope/node-sdk",
-      "version": "1.5.5",
+      "version": "1.5.7",
       "license": "MIT",
       "dependencies": {
-        "@descope/core-js-sdk": "1.4.6",
-        "jose": "4.14.4",
-        "node-fetch-commonjs": "3.3.1",
+        "@descope/core-js-sdk": "1.6.4",
+        "jose": "4.15.1",
+        "node-fetch-commonjs": "3.3.2",
         "tslib": "^1.14.1"
       },
       "devDependencies": {
@@ -1117,7 +1117,7 @@
     "@descope/node-sdk": {
       "version": "file:../..",
       "requires": {
-        "@descope/core-js-sdk": "1.4.6",
+        "@descope/core-js-sdk": "1.6.4",
         "@rollup/plugin-commonjs": "^25.0.0",
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^13.3.0",
@@ -1144,11 +1144,11 @@
         "eslint-plugin-prettier": "^4.0.0",
         "husky": "^8.0.1",
         "jest": "^29.0.0",
-        "jose": "4.14.4",
+        "jose": "4.15.1",
         "jsdoc": "^4.0.0",
         "lint-staged": "^13.0.3",
         "nock": "^13.2.4",
-        "node-fetch-commonjs": "3.3.1",
+        "node-fetch-commonjs": "3.3.2",
         "prettier": "^2.7.1",
         "pretty-quick": "^3.1.3",
         "rollup": "^2.62.0",

--- a/examples/managementCli/src/index.ts
+++ b/examples/managementCli/src/index.ts
@@ -507,6 +507,134 @@ program
     handleSdkRes(await sdk.management.audit.search({ text }), option.output);
   });
 
+// authz
+program
+  .command('authz-load-schema')
+  .description('Load and display the current schema')
+  .option('-o, --output <filename>', 'Output filename')
+  .action(async (option) => {
+    handleSdkRes(await sdk.management.authz.loadSchema(), option.output);
+  });
+
+program
+  .command('authz-save-schema')
+  .description('Save the schema defined in the given file')
+  .option('-i, --input <filename>', 'Schema input filename')
+  .action(async (option) => {
+    const file = fs.readFileSync(option.input, 'utf8');
+    const s = JSON.parse(file);
+    handleSdkRes(await sdk.management.authz.saveSchema(s, true), undefined);
+  });
+
+program
+  .command('authz-has-relation')
+  .description('Check if given target has relation for given resource')
+  .option('-r, --resource <resource>', 'The resource we are checking')
+  .option('-d, --relationDefinition <rd>', 'The relation definition name')
+  .option('-n, --namespace <ns>', 'The relation definition namespace')
+  .option('-t, --target <target>', 'The target we are checking')
+  .option('-o, --output <filename>', 'Output filename')
+  .action(async (option) => {
+    handleSdkRes(
+      await sdk.management.authz.hasRelations([
+        {
+          resource: option.resource,
+          relationDefinition: option.relationDefinition,
+          namespace: option.namespace,
+          target: option.target,
+        },
+      ]),
+      option.output,
+    );
+  });
+
+program
+  .command('authz-create-relation')
+  .description('Create a relation')
+  .option('-r, --resource <resource>', 'The resource for the relation')
+  .option('-d, --relationDefinition <rd>', 'The relation definition name')
+  .option('-n, --namespace <ns>', 'The relation definition namespace')
+  .option('-t, --target <target>', 'The target for the relation')
+  .action(async (option) => {
+    handleSdkRes(
+      await sdk.management.authz.createRelations([
+        {
+          resource: option.resource,
+          relationDefinition: option.relationDefinition,
+          namespace: option.namespace,
+          target: option.target,
+        },
+      ]),
+      undefined,
+    );
+  });
+
+program
+  .command('authz-delete-relation')
+  .description('Delete a relation')
+  .option('-r, --resource <resource>', 'The resource for the relation')
+  .option('-d, --relationDefinition <rd>', 'The relation definition name')
+  .option('-n, --namespace <ns>', 'The relation definition namespace')
+  .option('-t, --target <target>', 'The target for the relation')
+  .action(async (option) => {
+    handleSdkRes(
+      await sdk.management.authz.deleteRelations([
+        {
+          resource: option.resource,
+          relationDefinition: option.relationDefinition,
+          namespace: option.namespace,
+          target: option.target,
+        },
+      ]),
+      undefined,
+    );
+  });
+
+program
+  .command('authz-who-can-access')
+  .description('Display all relations for the given resource and rd')
+  .option('-r, --resource <resource>', 'The resource for the relation')
+  .option('-d, --relationDefinition <rd>', 'The relation definition name')
+  .option('-n, --namespace <ns>', 'The relation definition namespace')
+  .option('-o, --output <filename>', 'Output filename')
+  .action(async (option) => {
+    handleSdkRes(
+      await sdk.management.authz.whoCanAccess(
+        option.resource,
+        option.relationDefinition,
+        option.namespace,
+      ),
+      option.output,
+    );
+  });
+
+program
+  .command('authz-resource-relations')
+  .description('Load relations for the given resource')
+  .option('-r, --resource <resource>', 'The resource for the relations')
+  .option('-o, --output <filename>', 'Output filename')
+  .action(async (option) => {
+    handleSdkRes(await sdk.management.authz.resourceRelations(option.resource), option.output);
+  });
+
+program
+  .command('authz-target-relations')
+  .description('Load relations for the given target')
+  .option('-t, --target <target>', 'The target for the relations')
+  .option('-o, --output <filename>', 'Output filename')
+  .action(async (option) => {
+    handleSdkRes(await sdk.management.authz.targetsRelations([option.target]), option.output);
+  });
+
+program
+  .command('authz-target-access')
+  .description('Display all relations for the given target')
+  .argument('<target>', 'display all relations for given target')
+  .option('-o, --output <filename>', 'Output filename')
+  .action(async (target, option) => {
+    handleSdkRes(await sdk.management.authz.whatCanTargetAccess(target), option.output);
+  });
+
 // *** Helper functions ***
 
 function handleSdkRes(res: SdkResponse<any>, responseFile?: string) {

--- a/lib/management/authz.test.ts
+++ b/lib/management/authz.test.ts
@@ -1,0 +1,482 @@
+import { SdkResponse } from '@descope/core-js-sdk';
+import withManagement from '.';
+import apiPaths from './paths';
+import { mockCoreSdk, mockHttpClient } from './testutils';
+import { AuthzSchema, AuthzRelation, AuthzRelationQuery } from './types';
+
+const management = withManagement(mockCoreSdk, 'key');
+
+const mockLoadSchema = {
+  name: 'mock',
+  namespaces: [{ name: 'doc', relationDefinitions: [{ name: 'owner' }] }],
+};
+
+const mockLoadSchemaResponse = {
+  schema: mockLoadSchema,
+};
+
+const mockRelation = {
+  resource: 'roadmap.ppt',
+  relationDefinition: 'owner',
+  namespace: 'doc',
+  target: 'u1',
+};
+
+const mockRelationResponse = {
+  relations: [mockRelation],
+};
+
+const mockRelationQuery = {
+  resource: 'roadmap.ppt',
+  relationDefinition: 'owner',
+  namespace: 'doc',
+  target: 'u1',
+  hasRelation: true,
+};
+
+const mockRelationsQueryResponse = {
+  relationQueries: [mockRelationQuery],
+};
+
+describe('Management Authz', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    mockHttpClient.reset();
+  });
+
+  describe('loadSchema', () => {
+    it('should load the schema', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => mockLoadSchemaResponse,
+        clone: () => ({
+          json: () => Promise.resolve(mockLoadSchemaResponse),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const resp: SdkResponse<AuthzSchema> = await management.authz.loadSchema();
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        apiPaths.authz.schemaLoad,
+        {},
+        { token: 'key' },
+      );
+      expect(resp).toEqual({
+        code: 200,
+        data: mockLoadSchema,
+        ok: true,
+        response: httpResponse,
+      });
+    });
+  });
+
+  describe('saveSchema', () => {
+    it('should save the schema', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => {},
+        clone: () => ({
+          json: () => Promise.resolve({}),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const resp: SdkResponse<never> = await management.authz.saveSchema(mockLoadSchema, true);
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        apiPaths.authz.schemaSave,
+        { schema: mockLoadSchema, upgrade: true },
+        { token: 'key' },
+      );
+      expect(resp).toEqual({
+        code: 200,
+        data: {},
+        ok: true,
+        response: httpResponse,
+      });
+    });
+  });
+
+  describe('deleteSchema', () => {
+    it('should delete the schema', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => {},
+        clone: () => ({
+          json: () => Promise.resolve({}),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const resp: SdkResponse<never> = await management.authz.deleteSchema();
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        apiPaths.authz.schemaDelete,
+        {},
+        { token: 'key' },
+      );
+      expect(resp).toEqual({
+        code: 200,
+        data: {},
+        ok: true,
+        response: httpResponse,
+      });
+    });
+  });
+
+  describe('saveNamespace', () => {
+    it('should save the namespace', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => {},
+        clone: () => ({
+          json: () => Promise.resolve({}),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const resp: SdkResponse<never> = await management.authz.saveNamespace(
+        mockLoadSchema.namespaces[0],
+      );
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        apiPaths.authz.nsSave,
+        { namespace: mockLoadSchema.namespaces[0] },
+        { token: 'key' },
+      );
+      expect(resp).toEqual({
+        code: 200,
+        data: {},
+        ok: true,
+        response: httpResponse,
+      });
+    });
+  });
+
+  describe('deleteNamespace', () => {
+    it('should delete the namespace', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => {},
+        clone: () => ({
+          json: () => Promise.resolve({}),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const resp: SdkResponse<never> = await management.authz.deleteNamespace('doc');
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        apiPaths.authz.nsDelete,
+        { name: 'doc', schemaName: undefined },
+        { token: 'key' },
+      );
+      expect(resp).toEqual({
+        code: 200,
+        data: {},
+        ok: true,
+        response: httpResponse,
+      });
+    });
+  });
+
+  describe('saveRelationDefinition', () => {
+    it('should save the relation definition', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => {},
+        clone: () => ({
+          json: () => Promise.resolve({}),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const resp: SdkResponse<never> = await management.authz.saveRelationDefinition(
+        mockLoadSchema.namespaces[0].relationDefinitions[0],
+        'owner',
+      );
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        apiPaths.authz.rdSave,
+        {
+          relationDefinition: mockLoadSchema.namespaces[0].relationDefinitions[0],
+          namespace: 'owner',
+        },
+        { token: 'key' },
+      );
+      expect(resp).toEqual({
+        code: 200,
+        data: {},
+        ok: true,
+        response: httpResponse,
+      });
+    });
+  });
+
+  describe('deleteRelationDefinition', () => {
+    it('should delete the relation definition', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => {},
+        clone: () => ({
+          json: () => Promise.resolve({}),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const resp: SdkResponse<never> = await management.authz.deleteRelationDefinition(
+        'owner',
+        'doc',
+      );
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        apiPaths.authz.rdDelete,
+        { name: 'owner', namespace: 'doc', schemaName: undefined },
+        { token: 'key' },
+      );
+      expect(resp).toEqual({
+        code: 200,
+        data: {},
+        ok: true,
+        response: httpResponse,
+      });
+    });
+  });
+
+  describe('createRelations', () => {
+    it('should create relations', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => {},
+        clone: () => ({
+          json: () => Promise.resolve({}),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const resp: SdkResponse<never> = await management.authz.createRelations([mockRelation]);
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        apiPaths.authz.reCreate,
+        {
+          relations: [mockRelation],
+        },
+        { token: 'key' },
+      );
+      expect(resp).toEqual({
+        code: 200,
+        data: {},
+        ok: true,
+        response: httpResponse,
+      });
+    });
+  });
+
+  describe('deleteRelationsForResources', () => {
+    it('should delete the relations for given resource', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => {},
+        clone: () => ({
+          json: () => Promise.resolve({}),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const resp: SdkResponse<never> = await management.authz.deleteRelationsForResources(['x']);
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        apiPaths.authz.reDeleteResources,
+        { resources: ['x'] },
+        { token: 'key' },
+      );
+      expect(resp).toEqual({
+        code: 200,
+        data: {},
+        ok: true,
+        response: httpResponse,
+      });
+    });
+  });
+
+  describe('deleteRelations', () => {
+    it('should delete the relations', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => {},
+        clone: () => ({
+          json: () => Promise.resolve({}),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const resp: SdkResponse<never> = await management.authz.deleteRelations([mockRelation]);
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        apiPaths.authz.reDelete,
+        { relations: [mockRelation] },
+        { token: 'key' },
+      );
+      expect(resp).toEqual({
+        code: 200,
+        data: {},
+        ok: true,
+        response: httpResponse,
+      });
+    });
+  });
+
+  describe('hasRelations', () => {
+    it('should query the given relations', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => mockRelationsQueryResponse,
+        clone: () => ({
+          json: () => Promise.resolve(mockRelationsQueryResponse),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const resp: SdkResponse<AuthzRelationQuery[]> = await management.authz.hasRelations([
+        mockRelationQuery,
+      ]);
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        apiPaths.authz.hasRelations,
+        mockRelationsQueryResponse,
+        { token: 'key' },
+      );
+      expect(resp).toEqual({
+        code: 200,
+        data: [mockRelationQuery],
+        ok: true,
+        response: httpResponse,
+      });
+    });
+  });
+
+  describe('whoCanAccess', () => {
+    const targets = { targets: ['u1'] };
+    it('should query who can access the given resource using given rd', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => targets,
+        clone: () => ({
+          json: () => Promise.resolve(targets),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const resp: SdkResponse<string[]> = await management.authz.whoCanAccess('r', 'owner', 'doc');
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        apiPaths.authz.who,
+        { resource: 'r', relationDefinition: 'owner', namespace: 'doc' },
+        { token: 'key' },
+      );
+      expect(resp).toEqual({
+        code: 200,
+        data: ['u1'],
+        ok: true,
+        response: httpResponse,
+      });
+    });
+  });
+
+  describe('resourceRelations', () => {
+    it('should load the relations for the given resource', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => mockRelationResponse,
+        clone: () => ({
+          json: () => Promise.resolve(mockRelationResponse),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const resp: SdkResponse<AuthzRelation[]> = await management.authz.resourceRelations('r');
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        apiPaths.authz.resource,
+        { resource: 'r' },
+        { token: 'key' },
+      );
+      expect(resp).toEqual({
+        code: 200,
+        data: [mockRelation],
+        ok: true,
+        response: httpResponse,
+      });
+    });
+  });
+
+  describe('targetsRelations', () => {
+    it('should load the relations for the given targets', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => mockRelationResponse,
+        clone: () => ({
+          json: () => Promise.resolve(mockRelationResponse),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const resp: SdkResponse<AuthzRelation[]> = await management.authz.targetsRelations(['t']);
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        apiPaths.authz.targets,
+        { targets: ['t'] },
+        { token: 'key' },
+      );
+      expect(resp).toEqual({
+        code: 200,
+        data: [mockRelation],
+        ok: true,
+        response: httpResponse,
+      });
+    });
+  });
+
+  describe('whatCanTargetAccess', () => {
+    it('should load the relations for the given target including recursive', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => mockRelationResponse,
+        clone: () => ({
+          json: () => Promise.resolve(mockRelationResponse),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const resp: SdkResponse<AuthzRelation[]> = await management.authz.whatCanTargetAccess('t');
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        apiPaths.authz.targetAll,
+        { target: 't' },
+        { token: 'key' },
+      );
+      expect(resp).toEqual({
+        code: 200,
+        data: [mockRelation],
+        ok: true,
+        response: httpResponse,
+      });
+    });
+  });
+});

--- a/lib/management/authz.ts
+++ b/lib/management/authz.ts
@@ -1,0 +1,228 @@
+import { SdkResponse, transformResponse } from '@descope/core-js-sdk';
+import { CoreSdk } from '../types';
+import apiPaths from './paths';
+import {
+  AuthzSchema,
+  AuthzNamespace,
+  AuthzRelationDefinition,
+  AuthzRelation,
+  AuthzRelationQuery,
+} from './types';
+
+const WithAuthz = (sdk: CoreSdk, managementKey?: string) => ({
+  /**
+   * Save (create or update) the given schema.
+   * In case of update, will update only given namespaces and will not delete namespaces unless upgrade flag is true.
+   * Schema name can be used for projects to track versioning.
+   *
+   * @param schema the schema to save
+   * @param upgrade should we upgrade existing schema or ignore any namespace not provided
+   * @returns standard success or failure response
+   */
+  saveSchema: (schema: AuthzSchema, upgrade: boolean): Promise<SdkResponse<never>> =>
+    transformResponse(
+      sdk.httpClient.post(apiPaths.authz.schemaSave, { schema, upgrade }, { token: managementKey }),
+    ),
+  /**
+   * Delete the schema for the project which will also delete all relations.
+   *
+   * @returns standard success or failure response
+   */
+  deleteSchema: (): Promise<SdkResponse<never>> =>
+    transformResponse(
+      sdk.httpClient.post(apiPaths.authz.schemaDelete, {}, { token: managementKey }),
+    ),
+  /**
+   * Load the schema for the project.
+   *
+   * @returns the schema associated with the project
+   */
+  loadSchema: (): Promise<SdkResponse<AuthzSchema>> =>
+    transformResponse(
+      sdk.httpClient.post(apiPaths.authz.schemaLoad, {}, { token: managementKey }),
+      (data) => data.schema,
+    ),
+  /**
+   * Save (create or update) the given namespace.
+   * Will not delete relation definitions not mentioned in the namespace.
+   *
+   * @param namespace the namespace to save
+   * @param oldName if we are changing the namespace name, what was the old name we are updating.
+   * @param schemaName optional and used to track the current schema version.
+   * @returns standard success or failure response
+   */
+  saveNamespace: (
+    namespace: AuthzNamespace,
+    oldName?: string,
+    schemaName?: string,
+  ): Promise<SdkResponse<never>> =>
+    transformResponse(
+      sdk.httpClient.post(
+        apiPaths.authz.nsSave,
+        { namespace, oldName, schemaName },
+        { token: managementKey },
+      ),
+    ),
+  /**
+   * Delete the given namespace.
+   * Will also delete the relevant relations.
+   *
+   * @param name to delete.
+   * @param schemaName optional and used to track the current schema version.
+   * @returns standard success or failure response
+   */
+  deleteNamespace: (name: string, schemaName?: string): Promise<SdkResponse<never>> =>
+    transformResponse(
+      sdk.httpClient.post(apiPaths.authz.nsDelete, { name, schemaName }, { token: managementKey }),
+    ),
+  /**
+   * Save (create or update) the given relation definition.
+   *
+   * @param relationDefinition rd to save.
+   * @param namespace that it belongs to.
+   * @param oldName if we are changing the relation definition name, what was the old name we are updating.
+   * @param schemaName optional and used to track the current schema version.
+   * @returns standard success or failure response
+   */
+  saveRelationDefinition: (
+    relationDefinition: AuthzRelationDefinition,
+    namespace: string,
+    oldName?: string,
+    schemaName?: string,
+  ): Promise<SdkResponse<never>> =>
+    transformResponse(
+      sdk.httpClient.post(
+        apiPaths.authz.rdSave,
+        { relationDefinition, namespace, oldName, schemaName },
+        { token: managementKey },
+      ),
+    ),
+  /**
+   * Delete the given relation definition.
+   * Will also delete the relevant relations.
+   *
+   * @param name to delete.
+   * @param namespace it belongs to.
+   * @param schemaName optional and used to track the current schema version.
+   * @returns standard success or failure response
+   */
+  deleteRelationDefinition: (
+    name: string,
+    namespace: string,
+    schemaName?: string,
+  ): Promise<SdkResponse<never>> =>
+    transformResponse(
+      sdk.httpClient.post(
+        apiPaths.authz.rdDelete,
+        { name, namespace, schemaName },
+        { token: managementKey },
+      ),
+    ),
+  /**
+   * Create the given relations.
+   *
+   * @param relations to create.
+   * @returns standard success or failure response
+   */
+  createRelations: (relations: AuthzRelation[]): Promise<SdkResponse<never>> =>
+    transformResponse(
+      sdk.httpClient.post(apiPaths.authz.reCreate, { relations }, { token: managementKey }),
+    ),
+  /**
+   * Delete the given relations.
+   *
+   * @param relations to delete.
+   * @returns standard success or failure response
+   */
+  deleteRelations: (relations: AuthzRelation[]): Promise<SdkResponse<never>> =>
+    transformResponse(
+      sdk.httpClient.post(apiPaths.authz.reDelete, { relations }, { token: managementKey }),
+    ),
+  /**
+   * Delete the relations for the given resources.
+   *
+   * @param resources resources to delete relations for.
+   * @returns standard success or failure response
+   */
+  deleteRelationsForResources: (resources: string[]): Promise<SdkResponse<never>> =>
+    transformResponse(
+      sdk.httpClient.post(
+        apiPaths.authz.reDeleteResources,
+        { resources },
+        { token: managementKey },
+      ),
+    ),
+  /**
+   * Query relations to see what relations exists.
+   *
+   * @param relationQueries array of relation queries to check.
+   * @returns array of relation query responses with the boolean flag indicating if relation exists
+   */
+  hasRelations: (
+    relationQueries: AuthzRelationQuery[],
+  ): Promise<SdkResponse<AuthzRelationQuery[]>> =>
+    transformResponse(
+      sdk.httpClient.post(
+        apiPaths.authz.hasRelations,
+        { relationQueries },
+        { token: managementKey },
+      ),
+      (data) => data.relationQueries,
+    ),
+  /**
+   * List all the users that have the given relation definition to the given resource.
+   *
+   * @param resource The resource we are checking
+   * @param relationDefinition The relation definition we are querying
+   * @param namespace The namespace for the relation definition
+   * @returns array of users who have the given relation definition
+   */
+  whoCanAccess: (
+    resource: string,
+    relationDefinition: string,
+    namespace: string,
+  ): Promise<SdkResponse<string[]>> =>
+    transformResponse(
+      sdk.httpClient.post(
+        apiPaths.authz.who,
+        { resource, relationDefinition, namespace },
+        { token: managementKey },
+      ),
+      (data) => data.targets,
+    ),
+  /**
+   * Return the list of all defined relations (not recursive) on the given resource.
+   *
+   * @param resource The resource we are checking
+   * @returns array of relations that exist for the given resource
+   */
+  resourceRelations: (resource: string): Promise<SdkResponse<AuthzRelation[]>> =>
+    transformResponse(
+      sdk.httpClient.post(apiPaths.authz.resource, { resource }, { token: managementKey }),
+      (data) => data.relations,
+    ),
+  /**
+   * Return the list of all defined relations (not recursive) for the given targets.
+   *
+   * @param targets array of targets we want to check
+   * @returns array of relations that exist for the given targets
+   */
+  targetsRelations: (targets: string[]): Promise<SdkResponse<AuthzRelation[]>> =>
+    transformResponse(
+      sdk.httpClient.post(apiPaths.authz.targets, { targets }, { token: managementKey }),
+      (data) => data.relations,
+    ),
+  /**
+   * Return the list of all relations for the given target including derived relations from the schema tree.
+   *
+   * @param target The target to check relations for
+   * @returns array of relations that exist for the given targets
+   */
+  whatCanTargetAccess: (target: string): Promise<SdkResponse<AuthzRelation[]>> =>
+    transformResponse(
+      sdk.httpClient.post(apiPaths.authz.targetAll, { target }, { token: managementKey }),
+      (data) => data.relations,
+    ),
+});
+
+export default WithAuthz;

--- a/lib/management/index.ts
+++ b/lib/management/index.ts
@@ -11,6 +11,7 @@ import withAccessKey from './accesskey';
 import WithFlow from './flow';
 import WithTheme from './theme';
 import WithAudit from './audit';
+import WithAuthz from './authz';
 
 /** Constructs a higher level Management API that wraps the functions from code-js-sdk */
 const withManagement = (sdk: CoreSdk, managementKey?: string) => ({
@@ -26,6 +27,7 @@ const withManagement = (sdk: CoreSdk, managementKey?: string) => ({
   flow: WithFlow(sdk, managementKey),
   theme: WithTheme(sdk, managementKey),
   audit: WithAudit(sdk, managementKey),
+  authz: WithAuthz(sdk, managementKey),
 });
 
 export default withManagement;

--- a/lib/management/paths.ts
+++ b/lib/management/paths.ts
@@ -84,4 +84,21 @@ export default {
   audit: {
     search: '/v1/mgmt/audit/search',
   },
+  authz: {
+    schemaSave: '/v1/mgmt/authz/schema/save',
+    schemaDelete: '/v1/mgmt/authz/schema/delete',
+    schemaLoad: '/v1/mgmt/authz/schema/load',
+    nsSave: '/v1/mgmt/authz/ns/save',
+    nsDelete: '/v1/mgmt/authz/ns/delete',
+    rdSave: '/v1/mgmt/authz/rd/save',
+    rdDelete: '/v1/mgmt/authz/rd/delete',
+    reCreate: '/v1/mgmt/authz/re/create',
+    reDelete: '/v1/mgmt/authz/re/delete',
+    reDeleteResources: '/v1/mgmt/authz/re/deleteresources',
+    hasRelations: '/v1/mgmt/authz/re/has',
+    who: '/v1/mgmt/authz/re/who',
+    resource: '/v1/mgmt/authz/re/resource',
+    targets: '/v1/mgmt/authz/re/targets',
+    targetAll: '/v1/mgmt/authz/re/targetall',
+  },
 };

--- a/lib/management/types.ts
+++ b/lib/management/types.ts
@@ -240,3 +240,104 @@ export enum UserStatus {
   disabled = 'disabled',
   invited = 'invited',
 }
+
+export enum AuthzNodeExpressionType {
+  self = 'self', // direct relation expression
+  targetSet = 'targetSet', // expression via another relation definition target
+  relationLeft = 'relationLeft', // expression via parent relation like org within org and membership
+  relationRight = 'relationRight', // expression via child relation like folder within folder and owner
+}
+
+/**
+ * AuthzNodeExpression holds the definition of a child node
+ */
+export type AuthzNodeExpression = {
+  neType: AuthzNodeExpressionType;
+  relationDefinition?: string;
+  relationDefinitionNamespace?: string;
+  targetRelationDefinition?: string;
+  targetRelationDefinitionNamespace?: string;
+};
+
+export enum AuthzNodeType {
+  child = 'child', // regular child node in relation definition
+  // union node of multiple children
+  // Example: editor of document is union between
+  // 1. Direct editor relation - someone that has editor on document
+  // 2. Owner relation - someone who is owner of document
+  // 3. Editor of containing folder relation - someone who is editor of the folder that has parent relation to doc
+  union = 'union',
+  intersect = 'intersect', // intersect between multiple children
+  sub = 'sub', // sub between the first child and the rest
+}
+
+/**
+ * AuthzNode holds the definition of a complex relation definition
+ */
+export type AuthzNode = {
+  nType: AuthzNodeType;
+  children?: AuthzNode[];
+  expression?: AuthzNodeExpression;
+};
+
+/**
+ * AuthzRelationDefinition defines a relation within a namespace
+ */
+export type AuthzRelationDefinition = {
+  name: string;
+  complexDefinition?: AuthzNode;
+};
+
+/**
+ * AuthzNamespace defines an entity in the authorization schema
+ */
+export type AuthzNamespace = {
+  name: string;
+  relationDefinitions: AuthzRelationDefinition[];
+};
+
+/**
+ * AuthzSchema holds the full schema (all namespaces) for a project
+ */
+export type AuthzSchema = {
+  name?: string;
+  namespaces: AuthzNamespace[];
+};
+
+/**
+ * AuthzUserQuery represents a target of a relation for ABAC (query on users)
+ */
+export type AuthzUserQuery = {
+  tenants?: string[];
+  roles?: string[];
+  text?: string;
+  statuses?: UserStatus[];
+  ssoOnly?: boolean;
+  withTestUser?: boolean;
+  customAttributes?: Record<string, any>;
+};
+
+/**
+ * AuthzRelation defines a relation between resource and target
+ */
+export type AuthzRelation = {
+  resource: string;
+  relationDefinition: string;
+  namespace: string;
+  target?: string;
+  targetSetResource?: string;
+  targetSetRelationDefinition?: string;
+  targetSetRelationDefinitionNamespace?: string;
+  query?: AuthzUserQuery;
+};
+
+/**
+ * AuthzRelationQuery queries the service if a given relation exists
+ */
+export type AuthzRelationQuery = {
+  resource: string;
+  relationDefinition: string;
+  namespace: string;
+  target: string;
+  hasRelation?: boolean;
+};


### PR DESCRIPTION
## Description

Adds Descope Authz APIs to the Node management SDK

## Must

- [ ] Tests
- [ ] Documentation (if applicable)
