### PR TITLE
Add the ability to specify invite type

### DIFF
--- a/lib/management/user.test.ts
+++ b/lib/management/user.test.ts
@@ -194,6 +194,7 @@ describe('Management User', () => {
         false,
         false,
         'https://invite.me',
+        true,
       );
 
       expect(mockHttpClient.post).toHaveBeenCalledWith(
@@ -210,6 +211,7 @@ describe('Management User', () => {
           verifiedEmail: false,
           verifiedPhone: false,
           inviteUrl: 'https://invite.me',
+          sendMail: true,
         },
         { token: 'key' },
       );

--- a/lib/management/user.ts
+++ b/lib/management/user.ts
@@ -106,6 +106,8 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => ({
     verifiedEmail?: boolean,
     verifiedPhone?: boolean,
     inviteUrl?: string,
+    sendMail?: boolean, // send invite via mail, default is according to project settings
+    sendSMS?: boolean, // send invite via text message, default is according to project settings
   ): Promise<SdkResponse<UserResponse>> =>
     transformResponse<SingleUserResponse, UserResponse>(
       sdk.httpClient.post(
@@ -123,6 +125,8 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => ({
           verifiedEmail,
           verifiedPhone,
           inviteUrl,
+          sendMail,
+          sendSMS,
         },
         { token: managementKey },
       ),


### PR DESCRIPTION
## Description
Add the ability to specify invite type - Email / SMS

Related to: https://github.com/descope/etc/issues/4542

## Must
- [x] Tests
- [x] Documentation (if applicable)
