### PR TITLE
fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ const authMiddleware = async (req: Request, res: Response, next: NextFunction) =
     next();
   } catch (e) {
     res.status(401).json({
-      error: new Error('Unauthorized!'),
+      error: 'Unauthorized!',
     });
   }
 };


### PR DESCRIPTION


## Description
small readme fix, error should probably be of type string (also to be agnostic from the caller technology)

fyi  strinfigying an error gets an empty object, interesting: 
![image](https://github.com/descope/node-sdk/assets/10514677/a8a8f9c2-ea7c-4200-8c48-9cfb47922e00)
