### PR TITLE
Support additional login ids

### DIFF
--- a/lib/management/types.ts
+++ b/lib/management/types.ts
@@ -174,6 +174,7 @@ export type User = {
   verifiedEmail?: boolean;
   verifiedPhone?: boolean;
   test?: boolean;
+  additionalLoginIds?: string[];
 };
 
 export type UserMapping = {

--- a/lib/management/user.test.ts
+++ b/lib/management/user.test.ts
@@ -61,6 +61,10 @@ describe('Management User', () => {
         ['r1', 'r2'],
         null,
         { a: 'a', b: 1, c: true },
+        undefined,
+        undefined,
+        undefined,
+        ['id-1', 'id-2'],
       );
 
       expect(mockHttpClient.post).toHaveBeenCalledWith(
@@ -73,6 +77,7 @@ describe('Management User', () => {
           roleNames: ['r1', 'r2'],
           userTenants: null,
           customAttributes: { a: 'a', b: 1, c: true },
+          additionalLoginIds: ['id-1', 'id-2'],
         },
         { token: 'key' },
       );

--- a/lib/management/user.test.ts
+++ b/lib/management/user.test.ts
@@ -64,9 +64,9 @@ describe('Management User', () => {
         undefined,
         undefined,
         undefined,
-        '',
-        '',
-        '',
+        undefined,
+        undefined,
+        undefined,
         ['id-1', 'id-2'],
       );
 

--- a/lib/management/user.ts
+++ b/lib/management/user.ts
@@ -34,6 +34,7 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => ({
     picture?: string,
     verifiedEmail?: boolean,
     verifiedPhone?: boolean,
+    additionalLoginIds?: string[],
   ): Promise<SdkResponse<UserResponse>> =>
     transformResponse<SingleUserResponse, UserResponse>(
       sdk.httpClient.post(
@@ -49,6 +50,7 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => ({
           picture,
           verifiedEmail,
           verifiedPhone,
+          additionalLoginIds,
         },
         { token: managementKey },
       ),
@@ -75,6 +77,7 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => ({
     picture?: string,
     verifiedEmail?: boolean,
     verifiedPhone?: boolean,
+    additionalLoginIds?: string[],
   ): Promise<SdkResponse<UserResponse>> =>
     transformResponse<SingleUserResponse, UserResponse>(
       sdk.httpClient.post(
@@ -91,6 +94,7 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => ({
           picture,
           verifiedEmail,
           verifiedPhone,
+          additionalLoginIds,
         },
         { token: managementKey },
       ),
@@ -110,6 +114,7 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => ({
     inviteUrl?: string,
     sendMail?: boolean, // send invite via mail, default is according to project settings
     sendSMS?: boolean, // send invite via text message, default is according to project settings
+    additionalLoginIds?: string[],
   ): Promise<SdkResponse<UserResponse>> =>
     transformResponse<SingleUserResponse, UserResponse>(
       sdk.httpClient.post(
@@ -129,6 +134,7 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => ({
           inviteUrl,
           sendMail,
           sendSMS,
+          additionalLoginIds,
         },
         { token: managementKey },
       ),
@@ -165,6 +171,7 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => ({
     picture?: string,
     verifiedEmail?: boolean,
     verifiedPhone?: boolean,
+    additionalLoginIds?: string[],
   ): Promise<SdkResponse<UserResponse>> =>
     transformResponse<SingleUserResponse, UserResponse>(
       sdk.httpClient.post(
@@ -180,6 +187,7 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => ({
           picture,
           verifiedEmail,
           verifiedPhone,
+          additionalLoginIds,
         },
         { token: managementKey },
       ),


### PR DESCRIPTION
## Description
related to https://github.com/descope/etc/issues/4570

Support additional login ids to user mgmt api 