### PR TITLE
Switch from node-fetch-commonjs to cross-fetch

### DIFF
--- a/lib/fetch-polyfill.ts
+++ b/lib/fetch-polyfill.ts
@@ -1,11 +1,11 @@
-import nodeFetch, { Headers } from 'node-fetch-commonjs';
+import { fetch as crossFetch, Headers } from 'cross-fetch';
 
 globalThis.Headers ??= Headers;
 
 const highWaterMarkMb = 1024 * 1024 * 30; // 30MB
 
 // we are increasing the response buffer size due to an issue where node-fetch hangs when response is too big
-const patchedFetch = (...args: Parameters<typeof nodeFetch>) => {
+const patchedFetch = (...args: Parameters<typeof crossFetch>) => {
   // we can get Request on the first arg, or RequestInfo on the second arg
   // we want to make sure we are setting the "highWaterMark" so we are doing it on both args
   args.forEach((arg) => {
@@ -13,7 +13,7 @@ const patchedFetch = (...args: Parameters<typeof nodeFetch>) => {
     arg && ((arg as any).highWaterMark ??= highWaterMarkMb);
   });
 
-  return nodeFetch(...args);
+  return crossFetch(...args);
 };
 
 export default patchedFetch as unknown as typeof fetch;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@descope/core-js-sdk": "2.4.0",
+        "cross-fetch": "^4.0.0",
         "jose": "4.15.4",
-        "node-fetch-commonjs": "3.3.2",
         "tslib": "^1.14.1"
       },
       "devDependencies": {
@@ -4182,6 +4182,14 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/cross-fetch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -9527,38 +9535,23 @@
         "node": ">= 10.13"
       }
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch-commonjs": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch-commonjs/-/node-fetch-commonjs-3.3.2.tgz",
-      "integrity": "sha512-VBlAiynj3VMLrotgwOS3OyECFxas5y7ltLcK4t41lMUZeaK15Ym4QRkqN0EQKAFL42q9i21EPKjzLUPfltR72A==",
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
+        "whatwg-url": "^5.0.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": "4.x || >=6.0.0"
       },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-int64": {
@@ -11849,6 +11842,11 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "node_modules/ts-jest": {
       "version": "29.0.5",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.0.5.tgz",
@@ -12247,12 +12245,18 @@
         "makeerror": "1.0.12"
       }
     },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
-      "engines": {
-        "node": ">= 8"
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -102,8 +102,8 @@
   },
   "dependencies": {
     "@descope/core-js-sdk": "2.4.0",
+    "cross-fetch": "^4.0.0",
     "jose": "4.15.4",
-    "node-fetch-commonjs": "3.3.2",
     "tslib": "^1.14.1"
   }
 }


### PR DESCRIPTION
## Description

* node-fetch-commonjs uses a load mechanism that requires various Node libraries even if a fetch implementation already exists. This causes issues on Cloudflare (and probably other edge runtimes) where we don't run in a full Node environment, but do have an existing fetch implementation.
* cross-fetch uses node-fetch under the hood, but provides for a nicer and safer load mechanism that does nothing if there is already an existing fetch implementation.

Fixes #305 
