### PR TITLE
Tenant Multi Domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -701,11 +701,11 @@ const idpURL = 'https://idp.com'
 const entityID = 'my-idp-entity-id'
 const idpCert = '<your-cert-here>'
 const redirectURL = 'https://my-app.com/handle-saml' // Global redirect URL for SSO/SAML
-const domain = 'tenant-users.com' // Users authentication with this domain will be logged in to this tenant
-await descopeClient.management.sso.configureSettings(tenantID, idpURL, entityID, idpCert, redirectURL, domain)
+const domains = ['tenant-users.com'] // Users authentication with this domain will be logged in to this tenant
+await descopeClient.management.sso.configureSettings(tenantID, idpURL, entityID, idpCert, redirectURL, domains)
 
 // Alternatively, configure using an SSO metadata URL
-await descopeClient.management.sso.configureMetadata(tenantID, 'https://idp.com/my-idp-metadata', redirectURL, domain)
+await descopeClient.management.sso.configureMetadata(tenantID, 'https://idp.com/my-idp-metadata', redirectURL, domains)
 
 // Map IDP groups to Descope roles, or map user attributes.
 // This function overrides any previous mapping (even when empty). Use carefully.

--- a/lib/management/sso.test.ts
+++ b/lib/management/sso.test.ts
@@ -16,6 +16,7 @@ describe('Management SSO', () => {
         tenantId: 'tenant-id',
         idpEntityId: 'idpEntityId',
         domain: 'some-domain.com',
+        domains: ['some-domain.com', 'some-domain2.com'],
       };
       const httpResponse = {
         ok: true,
@@ -89,19 +90,19 @@ describe('Management SSO', () => {
       const idpCert = 'cert';
       const entityId = 'e1';
       const redirectURL = 'https://redirect.com';
-      const domain = 'domain.com';
+      const domains = ['domain.com', 'app.domain.com'];
       const resp = await management.sso.configureSettings(
         tenantId,
         idpURL,
         idpCert,
         entityId,
         redirectURL,
-        domain,
+        domains,
       );
 
       expect(mockHttpClient.post).toHaveBeenCalledWith(
         apiPaths.sso.settings,
-        { tenantId, idpURL, idpCert, entityId, redirectURL, domain },
+        { tenantId, idpURL, idpCert, entityId, redirectURL, domains },
         { token: 'key' },
       );
 
@@ -127,12 +128,12 @@ describe('Management SSO', () => {
       const tenantId = 't1';
       const idpMetadataURL = 'https://idp.com';
       const redirectURL = 'https://redirect.com';
-      const domain = 'domain.com';
+      const domains = ['domain.com', 'app.domain.com'];
       const resp = await management.sso.configureMetadata(
         tenantId,
         idpMetadataURL,
         redirectURL,
-        domain,
+        domains,
       );
 
       expect(mockHttpClient.post).toHaveBeenCalledWith(
@@ -140,7 +141,7 @@ describe('Management SSO', () => {
         {
           tenantId,
           idpMetadataURL,
-          domain,
+          domains,
           redirectURL,
         },
         { token: 'key' },

--- a/lib/management/sso.ts
+++ b/lib/management/sso.ts
@@ -25,12 +25,12 @@ const withSSOSettings = (sdk: CoreSdk, managementKey?: string) => ({
     idpCert: string,
     entityId: string,
     redirectURL: string,
-    domain: string,
+    domains: string[],
   ): Promise<SdkResponse<never>> =>
     transformResponse(
       sdk.httpClient.post(
         apiPaths.sso.settings,
-        { tenantId, idpURL, entityId, idpCert, redirectURL, domain },
+        { tenantId, idpURL, entityId, idpCert, redirectURL, domains },
         { token: managementKey },
       ),
     ),
@@ -38,12 +38,12 @@ const withSSOSettings = (sdk: CoreSdk, managementKey?: string) => ({
     tenantId: string,
     idpMetadataURL: string,
     redirectURL: string,
-    domain: string,
+    domains: string[],
   ): Promise<SdkResponse<never>> =>
     transformResponse(
       sdk.httpClient.post(
         apiPaths.sso.metadata,
-        { tenantId, idpMetadataURL, redirectURL, domain },
+        { tenantId, idpMetadataURL, redirectURL, domains },
         { token: managementKey },
       ),
     ),

--- a/lib/management/types.ts
+++ b/lib/management/types.ts
@@ -207,6 +207,8 @@ export type SSOSettingsResponse = {
   userMapping: UserMapping;
   groupsMapping: GroupsMapping[];
   redirectUrl: string;
+  domains: string[];
+  // Deprecated - use domains instead
   domain: string;
 };
 


### PR DESCRIPTION
## Related Issues
Related to https://github.com/descope/etc/issues/4444

Depends on https://github.com/descope/managementservice/pull/686

## Description
Makes the tenant domain field be an array of values instead of just one.