### PR TITLE
Add the ability to pass login options to test user generate methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1125,6 +1125,7 @@ const { code } = await descopeClient.management.user.generateOTPForTestUser(
   'desmond@descope.com',
 );
 // Now you can verify the code is valid (using descopeClient.auth.*.verify for example)
+// LoginOptions can be provided to set custom claims to the generated jwt.
 
 // Same as OTP, magic link can be generated for test user, for example:
 const { link } = await descopeClient.management.user.generateMagicLinkForTestUser(

--- a/lib/management/user.test.ts
+++ b/lib/management/user.test.ts
@@ -1,4 +1,4 @@
-import { SdkResponse, UserResponse } from '@descope/core-js-sdk';
+import { LoginOptions, SdkResponse, UserResponse } from '@descope/core-js-sdk';
 import withManagement from '.';
 import apiPaths from './paths';
 import { mockCoreSdk, mockHttpClient } from './testutils';
@@ -1071,12 +1071,15 @@ describe('Management User', () => {
       };
       mockHttpClient.post.mockResolvedValue(httpResponse);
 
+      const loginOptions: LoginOptions = {
+        stepup: true,
+      };
       const resp: SdkResponse<GenerateOTPForTestResponse> =
-        await management.user.generateOTPForTestUser('sms', 'some-id');
+        await management.user.generateOTPForTestUser('sms', 'some-id', loginOptions);
 
       expect(mockHttpClient.post).toHaveBeenCalledWith(
         apiPaths.user.generateOTPForTest,
-        { loginId: 'some-id', deliveryMethod: 'sms' },
+        { loginId: 'some-id', deliveryMethod: 'sms', loginOptions },
         { token: 'key' },
       );
 
@@ -1102,12 +1105,20 @@ describe('Management User', () => {
       };
       mockHttpClient.post.mockResolvedValue(httpResponse);
 
+      const loginOptions: LoginOptions = {
+        stepup: true,
+      };
       const resp: SdkResponse<GenerateMagicLinkForTestResponse> =
-        await management.user.generateMagicLinkForTestUser('email', 'some-id', 'some-uri');
+        await management.user.generateMagicLinkForTestUser(
+          'email',
+          'some-id',
+          'some-uri',
+          loginOptions,
+        );
 
       expect(mockHttpClient.post).toHaveBeenCalledWith(
         apiPaths.user.generateMagicLinkForTest,
-        { loginId: 'some-id', deliveryMethod: 'email', URI: 'some-uri' },
+        { loginId: 'some-id', deliveryMethod: 'email', URI: 'some-uri', loginOptions },
         { token: 'key' },
       );
 
@@ -1137,12 +1148,15 @@ describe('Management User', () => {
       };
       mockHttpClient.post.mockResolvedValue(httpResponse);
 
+      const loginOptions: LoginOptions = {
+        stepup: true,
+      };
       const resp: SdkResponse<GenerateEnchantedLinkForTestResponse> =
-        await management.user.generateEnchantedLinkForTestUser('some-id', 'some-uri');
+        await management.user.generateEnchantedLinkForTestUser('some-id', 'some-uri', loginOptions);
 
       expect(mockHttpClient.post).toHaveBeenCalledWith(
         apiPaths.user.generateEnchantedLinkForTest,
-        { loginId: 'some-id', URI: 'some-uri' },
+        { loginId: 'some-id', URI: 'some-uri', loginOptions },
         { token: 'key' },
       );
 

--- a/lib/management/user.test.ts
+++ b/lib/management/user.test.ts
@@ -1090,6 +1090,38 @@ describe('Management User', () => {
         response: httpResponse,
       });
     });
+
+    it('should send the correct request and receive correct response when passing embedded delivery method', async () => {
+      const mockResponse = { loginId: 'some-id', code: '123456' };
+      const httpResponse = {
+        ok: true,
+        json: () => mockResponse,
+        clone: () => ({
+          json: () => Promise.resolve(mockResponse),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const loginOptions: LoginOptions = {
+        stepup: true,
+      };
+      const resp: SdkResponse<GenerateOTPForTestResponse> =
+        await management.user.generateOTPForTestUser('Embedded', 'some-id', loginOptions);
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        apiPaths.user.generateOTPForTest,
+        { loginId: 'some-id', deliveryMethod: 'Embedded', loginOptions },
+        { token: 'key' },
+      );
+
+      expect(resp).toEqual({
+        code: 200,
+        data: mockResponse,
+        ok: true,
+        response: httpResponse,
+      });
+    });
   });
 
   describe('generateMagicLinkForTestUser', () => {

--- a/lib/management/user.ts
+++ b/lib/management/user.ts
@@ -1,4 +1,10 @@
-import { DeliveryMethod, SdkResponse, transformResponse, UserResponse } from '@descope/core-js-sdk';
+import {
+  DeliveryMethod,
+  SdkResponse,
+  transformResponse,
+  UserResponse,
+  LoginOptions,
+} from '@descope/core-js-sdk';
 import {
   ProviderTokenResponse,
   AssociatedTenant,
@@ -509,16 +515,18 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => ({
    *
    * @param deliveryMethod optional DeliveryMethod
    * @param loginId login ID of a test user
+   * @param loginOptions optional LoginOptions - can be provided to set custom claims to the generated jwt.
    * @returns GenerateOTPForTestResponse which includes the loginId and the OTP code
    */
   generateOTPForTestUser: (
     deliveryMethod: DeliveryMethod,
     loginId: string,
+    loginOptions?: LoginOptions,
   ): Promise<SdkResponse<GenerateOTPForTestResponse>> =>
     transformResponse<GenerateOTPForTestResponse>(
       sdk.httpClient.post(
         apiPaths.user.generateOTPForTest,
-        { deliveryMethod, loginId },
+        { deliveryMethod, loginId, loginOptions },
         { token: managementKey },
       ),
       (data) => data,
@@ -533,17 +541,19 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => ({
    * @param deliveryMethod optional DeliveryMethod
    * @param loginId login ID of a test user
    * @param uri optional redirect uri which will be used instead of any global configuration.
+   * @param loginOptions optional LoginOptions - can be provided to set custom claims to the generated jwt.
    * @returns GenerateMagicLinkForTestResponse which includes the loginId and the magic link
    */
   generateMagicLinkForTestUser: (
     deliveryMethod: DeliveryMethod,
     loginId: string,
     uri: string,
+    loginOptions?: LoginOptions,
   ): Promise<SdkResponse<GenerateMagicLinkForTestResponse>> =>
     transformResponse<GenerateMagicLinkForTestResponse>(
       sdk.httpClient.post(
         apiPaths.user.generateMagicLinkForTest,
-        { deliveryMethod, loginId, URI: uri },
+        { deliveryMethod, loginId, URI: uri, loginOptions },
         { token: managementKey },
       ),
       (data) => data,
@@ -557,16 +567,18 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => ({
    *
    * @param loginId login ID of a test user
    * @param uri optional redirect uri which will be used instead of any global configuration.
+   * @param loginOptions optional LoginOptions - can be provided to set custom claims to the generated jwt.
    * @returns GenerateEnchantedLinkForTestResponse which includes the loginId, the enchanted link and the pendingRef
    */
   generateEnchantedLinkForTestUser: (
     loginId: string,
     uri: string,
+    loginOptions?: LoginOptions,
   ): Promise<SdkResponse<GenerateEnchantedLinkForTestResponse>> =>
     transformResponse<GenerateEnchantedLinkForTestResponse>(
       sdk.httpClient.post(
         apiPaths.user.generateEnchantedLinkForTest,
-        { loginId, URI: uri },
+        { loginId, URI: uri, loginOptions },
         { token: managementKey },
       ),
       (data) => data,

--- a/lib/management/user.ts
+++ b/lib/management/user.ts
@@ -1,10 +1,4 @@
-import {
-  DeliveryMethod,
-  SdkResponse,
-  transformResponse,
-  UserResponse,
-  LoginOptions,
-} from '@descope/core-js-sdk';
+import { SdkResponse, transformResponse, UserResponse, LoginOptions } from '@descope/core-js-sdk';
 import {
   ProviderTokenResponse,
   AssociatedTenant,
@@ -17,7 +11,7 @@ import {
   User,
   InviteBatchResponse,
 } from './types';
-import { CoreSdk } from '../types';
+import { CoreSdk, DeliveryMethodForTestUser } from '../types';
 import apiPaths from './paths';
 
 type SingleUserResponse = {
@@ -519,7 +513,7 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => ({
    * @returns GenerateOTPForTestResponse which includes the loginId and the OTP code
    */
   generateOTPForTestUser: (
-    deliveryMethod: DeliveryMethod,
+    deliveryMethod: DeliveryMethodForTestUser,
     loginId: string,
     loginOptions?: LoginOptions,
   ): Promise<SdkResponse<GenerateOTPForTestResponse>> =>
@@ -545,7 +539,7 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => ({
    * @returns GenerateMagicLinkForTestResponse which includes the loginId and the magic link
    */
   generateMagicLinkForTestUser: (
-    deliveryMethod: DeliveryMethod,
+    deliveryMethod: DeliveryMethodForTestUser,
     loginId: string,
     uri: string,
     loginOptions?: LoginOptions,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,4 +1,4 @@
-import createSdk from '@descope/core-js-sdk';
+import createSdk, { DeliveryMethod } from '@descope/core-js-sdk';
 
 type Head<T extends ReadonlyArray<any>> = T extends readonly [] ? never : T[0];
 
@@ -21,3 +21,4 @@ export interface AuthenticationInfo {
 export type CreateCoreSdk = typeof createSdk;
 export type CoreSdkConfig = Head<Parameters<CreateCoreSdk>>;
 export type CoreSdk = ReturnType<CreateCoreSdk>;
+export type DeliveryMethodForTestUser = DeliveryMethod | 'Embedded';

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
-        "@descope/core-js-sdk": "2.5.0",
+        "@descope/core-js-sdk": "2.5.1",
         "cross-fetch": "^4.0.0",
         "jose": "4.15.4",
         "tslib": "^1.14.1"
@@ -670,9 +670,9 @@
       }
     },
     "node_modules/@descope/core-js-sdk": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.5.0.tgz",
-      "integrity": "sha512-U6fRnsHSRu8SbkHdmOVuuiO+mEEAvm8kJL6/6jYRLmWtofmJBKCqys5+XFLKnAEVAByPeVY8ls7uY2tGYfqSRA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.5.1.tgz",
+      "integrity": "sha512-fpTmCVS3fOpYOWBt/5xJ1h8B4edu5mHwpsBzuJgmeW+4BqYK9dzwSCZia+vPAbNIbFBL18ar1yILMIeARNw4EA==",
       "dependencies": {
         "jwt-decode": "3.1.2",
         "lodash.get": "4.4.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
-        "@descope/core-js-sdk": "2.4.0",
+        "@descope/core-js-sdk": "2.5.0",
         "cross-fetch": "^4.0.0",
         "jose": "4.15.4",
         "tslib": "^1.14.1"
@@ -670,9 +670,9 @@
       }
     },
     "node_modules/@descope/core-js-sdk": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.4.0.tgz",
-      "integrity": "sha512-tH7LzGCfDfHHoFnqiFf5FfAXknTNTAq2Lz+LBw49kDIe3Fmsv4gAU/5gFRvHrs0lakzgccw3BNwrDtLO5ni5+g==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.5.0.tgz",
+      "integrity": "sha512-U6fRnsHSRu8SbkHdmOVuuiO+mEEAvm8kJL6/6jYRLmWtofmJBKCqys5+XFLKnAEVAByPeVY8ls7uY2tGYfqSRA==",
       "dependencies": {
         "jwt-decode": "3.1.2",
         "lodash.get": "4.4.2"

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "typescript": "^4.6.4"
   },
   "dependencies": {
-    "@descope/core-js-sdk": "2.5.0",
+    "@descope/core-js-sdk": "2.5.1",
     "cross-fetch": "^4.0.0",
     "jose": "4.15.4",
     "tslib": "^1.14.1"

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "typescript": "^4.6.4"
   },
   "dependencies": {
-    "@descope/core-js-sdk": "2.4.0",
+    "@descope/core-js-sdk": "2.5.0",
     "cross-fetch": "^4.0.0",
     "jose": "4.15.4",
     "tslib": "^1.14.1"


### PR DESCRIPTION
## Description
Add the ability to pass login options to test user generate methods

Related to: https://github.com/descope/etc/issues/5093

## Must
- [x] Tests
- [x] Documentation (if applicable)
