### PR TITLE
Add types support for customAttributes in SDK

### DIFF
--- a/lib/management/types.ts
+++ b/lib/management/types.ts
@@ -62,6 +62,7 @@ export type Tenant = {
   id: string;
   name: string;
   selfProvisioningDomains: string[];
+  customAttributes?: Record<string, string | number | boolean>;
 };
 
 /** Represents a permission in a project. It has a name and optionally a description.


### PR DESCRIPTION
## Related Issues

Types are missing customAttributes in Tenant

## Description

Tenants have customAttributes and the type doesn't reflect this

## Must

- [x] Tests -> NA
- [x] Documentation (if applicable)
