### PR TITLE
Add user history support for mgmt apis

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,11 +430,9 @@ For multi-tenant uses:
 
 ```typescript
 // You can validate specific permissions
-const validTenantPermissions = descopeClient.validateTenantPermissions(
-  authInfo,
-  'my-tenant-ID',
-  ['Permission to validate'],
-);
+const validTenantPermissions = descopeClient.validateTenantPermissions(authInfo, 'my-tenant-ID', [
+  'Permission to validate',
+]);
 if (!validTenantPermissions) {
   // Deny access
 }
@@ -449,14 +447,14 @@ if (!validTenantRoles) {
 
 // Or get the matched roles/permissions
 const matchedTenantRoles = descopeClient.getMatchedTenantRoles(authInfo, 'my-tenant-ID', [
-	'Role to validate',
-	'Another role to validate'
+  'Role to validate',
+  'Another role to validate',
 ]);
 
 const matchedTenantPermissions = descopeClient.getMatchedTenantPermissions(
-	authInfo,
-	'my-tenant-ID',
-	['Permission to validate', 'Another permission to validate']],
+  authInfo,
+  'my-tenant-ID',
+  ['Permission to validate', 'Another permission to validate'],
 );
 ```
 
@@ -641,7 +639,14 @@ usersRes.data.forEach((user) => {
 
 await descopeClient.management.user.logoutUser('my-custom-id');
 
-await descopeClient.management.tenant.logoutUserByUserId('<user-ID>');
+await descopeClient.management.user.logoutUserByUserId('<user-ID>');
+
+// Get users' authentication history
+const userIds = ['user-id-1', 'user-id-2'];
+const usersHistoryRes = await descopeClient.management.user.history(userIds);
+usersHistoryRes.forEach((userHistory) => {
+  // do something
+});
 ```
 
 #### Set or Expire User Password

--- a/lib/management/paths.ts
+++ b/lib/management/paths.ts
@@ -29,6 +29,7 @@ export default {
     generateMagicLinkForTest: '/v1/mgmt/tests/generate/magiclink',
     generateEnchantedLinkForTest: '/v1/mgmt/tests/generate/enchantedlink',
     generateEmbeddedLink: '/v1/mgmt/user/signin/embeddedlink',
+    history: '/v1/mgmt/user/history',
   },
   project: {
     updateName: '/v1/mgmt/project/update/name',

--- a/lib/management/types.ts
+++ b/lib/management/types.ts
@@ -161,6 +161,14 @@ export type GenerateEmbeddedLinkResponse = {
   token: string;
 };
 
+export type UserHistoryResponse = {
+  userId: string;
+  loginTime: number;
+  city: string;
+  country: string;
+  ip: string;
+};
+
 export type AttributesTypes = string | boolean | number;
 
 export type User = {

--- a/lib/management/types.ts
+++ b/lib/management/types.ts
@@ -161,14 +161,6 @@ export type GenerateEmbeddedLinkResponse = {
   token: string;
 };
 
-export type UserHistoryResponse = {
-  userId: string;
-  loginTime: number;
-  city: string;
-  country: string;
-  ip: string;
-};
-
 export type AttributesTypes = string | boolean | number;
 
 export type User = {

--- a/lib/management/user.test.ts
+++ b/lib/management/user.test.ts
@@ -1545,4 +1545,48 @@ describe('Management User', () => {
       });
     });
   });
+
+  describe('history', () => {
+    it('should send the correct request and receive correct response', async () => {
+      const usersHistoryRes = [
+        {
+          userId: 'some-id-1',
+          loginTime: 12,
+          city: 'aa-1',
+          country: 'bb-1',
+          ip: 'cc-1',
+        },
+        {
+          userId: 'some-id-2',
+          loginTime: 21,
+          city: 'aa-2',
+          country: 'bb-2',
+          ip: 'cc-2',
+        },
+      ];
+      const httpResponse = {
+        ok: true,
+        json: () => usersHistoryRes,
+        clone: () => ({
+          json: () => Promise.resolve(usersHistoryRes),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const userIds = ['some-id-1', 'some-id-2'];
+      const resp = await management.user.history(userIds);
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.history, userIds, {
+        token: 'key',
+      });
+
+      expect(resp).toEqual({
+        code: 200,
+        data: usersHistoryRes,
+        ok: true,
+        response: httpResponse,
+      });
+    });
+  });
 });

--- a/lib/management/user.ts
+++ b/lib/management/user.ts
@@ -1,4 +1,10 @@
-import { SdkResponse, transformResponse, UserResponse, LoginOptions } from '@descope/core-js-sdk';
+import {
+  SdkResponse,
+  transformResponse,
+  UserHistoryResponse,
+  UserResponse,
+  LoginOptions,
+} from '@descope/core-js-sdk';
 import { deprecate } from 'util';
 import {
   ProviderTokenResponse,
@@ -11,7 +17,6 @@ import {
   UserStatus,
   User,
   InviteBatchResponse,
-  UserHistoryResponse,
 } from './types';
 import { CoreSdk, DeliveryMethodForTestUser } from '../types';
 import apiPaths from './paths';

--- a/lib/management/user.ts
+++ b/lib/management/user.ts
@@ -11,6 +11,7 @@ import {
   UserStatus,
   User,
   InviteBatchResponse,
+  UserHistoryResponse,
 } from './types';
 import { CoreSdk, DeliveryMethodForTestUser } from '../types';
 import apiPaths from './paths';
@@ -831,6 +832,16 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
     removeAllPasskeys: (loginId: string): Promise<SdkResponse<never>> =>
       transformResponse<never>(
         sdk.httpClient.post(apiPaths.user.removeAllPasskeys, { loginId }, { token: managementKey }),
+        (data) => data,
+      ),
+
+    /**
+     * Retrieve users' authentication history, by the given user's ids.
+     * @param userIds The user IDs
+     */
+    history: (userIds: string[]): Promise<SdkResponse<UserHistoryResponse[]>> =>
+      transformResponse<UserHistoryResponse[]>(
+        sdk.httpClient.post(apiPaths.user.history, userIds, { token: managementKey }),
         (data) => data,
       ),
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.6.3",
       "license": "MIT",
       "dependencies": {
-        "@descope/core-js-sdk": "2.8.2",
+        "@descope/core-js-sdk": "2.9.0",
         "cross-fetch": "^4.0.0",
         "jose": "4.15.4",
         "tslib": "^1.14.1"
@@ -669,9 +669,9 @@
       }
     },
     "node_modules/@descope/core-js-sdk": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.8.2.tgz",
-      "integrity": "sha512-73YVMjF3DouBz0hLbLsAPGVyYvBlm0AcRQbLj9YZSURlGI0yiROOTfVU2YTqauHCTnXjJgUJeTB1FALRk5SJVg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.9.0.tgz",
+      "integrity": "sha512-yZZIKRRyvLl/hpdDg1LPgZghfj4klkUyILTERWlBZh9vt8bIBzOqFrqkNcfDfVhxts15dYwlPMykQG8ssQ/Unw==",
       "dependencies": {
         "jwt-decode": "3.1.2",
         "lodash.get": "4.4.2"

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "typescript": "^4.6.4"
   },
   "dependencies": {
-    "@descope/core-js-sdk": "2.8.2",
+    "@descope/core-js-sdk": "2.9.0",
     "cross-fetch": "^4.0.0",
     "jose": "4.15.4",
     "tslib": "^1.14.1"


### PR DESCRIPTION
## Related Issues

Related to: https://github.com/descope/etc/issues/4713

## Description

Add user history support for mgmt apis.
Also updated to latest core-js-sdk.

## Must

- [x] Tests
- [x] Documentation (if applicable)
