### PR TITLE
Replace nodejs util deprecate

### DIFF
--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -91,7 +91,7 @@ export function isUserAssociatedWithTenant(authInfo: AuthenticationInfo, tenant:
 /**
  * Wrap a function with a deprecation warning
  */
-export function deprecate<T extends(...args: any[]) => any>(
+export function deprecate<T extends (...args: any[]) => any>(
   fn: T,
   message: string,
 ): (...args: Parameters<T>) => ReturnType<T> {

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -91,8 +91,11 @@ export function isUserAssociatedWithTenant(authInfo: AuthenticationInfo, tenant:
 /**
  * Wrap a function with a deprecation warning
  */
-export function deprecate(fn: Function, message: string) {
-  return (...args: any[]) => {
+export function deprecate<T extends(...args: any[]) => any>(
+  fn: T,
+  message: string,
+): (...args: Parameters<T>) => ReturnType<T> {
+  return (...args: Parameters<T>): ReturnType<T> => {
     // eslint-disable-next-line no-console
     console.warn(message);
     return fn(...args);

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -87,3 +87,14 @@ export function getAuthorizationClaimItems(
 export function isUserAssociatedWithTenant(authInfo: AuthenticationInfo, tenant: string): boolean {
   return !!authInfo.token[authorizedTenantsClaimName]?.[tenant];
 }
+
+/**
+ * Wrap a function with a deprecation warning
+ */
+export function deprecate(fn: Function, message: string) {
+  return (...args: any[]) => {
+    // eslint-disable-next-line no-console
+    console.warn(message);
+    return fn(...args);
+  };
+}

--- a/lib/management/sso.ts
+++ b/lib/management/sso.ts
@@ -1,5 +1,4 @@
 import { SdkResponse, transformResponse } from '@descope/core-js-sdk';
-import { deprecate } from 'util';
 import { CoreSdk } from '../types';
 import apiPaths from './paths';
 import {
@@ -11,6 +10,7 @@ import {
   SSOSAMLByMetadataSettings,
   SSOSettings,
 } from './types';
+import { deprecate } from '../helpers';
 
 const withSSOSettings = (sdk: CoreSdk, managementKey?: string) => ({
   getSettings: deprecate(

--- a/lib/management/user.ts
+++ b/lib/management/user.ts
@@ -5,7 +5,6 @@ import {
   UserResponse,
   LoginOptions,
 } from '@descope/core-js-sdk';
-import { deprecate } from 'util';
 import {
   ProviderTokenResponse,
   AssociatedTenant,
@@ -20,6 +19,7 @@ import {
 } from './types';
 import { CoreSdk, DeliveryMethodForTestUser } from '../types';
 import apiPaths from './paths';
+import { deprecate } from '../helpers';
 
 type SearchSort = {
   field: string;


### PR DESCRIPTION


## Description
Replace nodejs util deprecate
this function is not supported in [edge api](https://nextjs.org/docs/app/api-reference/edge)