### PR TITLE
replace deprecated with jsdocs

### DIFF
--- a/lib/management/sso.ts
+++ b/lib/management/sso.ts
@@ -1,5 +1,4 @@
 import { SdkResponse, transformResponse } from '@descope/core-js-sdk';
-import { deprecate } from 'util';
 import { CoreSdk } from '../types';
 import apiPaths from './paths';
 import {
@@ -13,17 +12,17 @@ import {
 } from './types';
 
 const withSSOSettings = (sdk: CoreSdk, managementKey?: string) => ({
-  getSettings: deprecate(
-    (tenantId: string): Promise<SdkResponse<SSOSettingsResponse>> =>
-      transformResponse<SSOSettingsResponse>(
-        sdk.httpClient.get(apiPaths.sso.settings, {
-          queryParams: { tenantId },
-          token: managementKey,
-        }),
-        (data) => data,
-      ),
-    'getSettings is deprecated, please use loadSettings instead',
-  ),
+  /**
+   * @deprecated  Use loadSettings instead
+   */
+  getSettings: (tenantId: string): Promise<SdkResponse<SSOSettingsResponse>> =>
+    transformResponse<SSOSettingsResponse>(
+      sdk.httpClient.get(apiPaths.sso.settings, {
+        queryParams: { tenantId },
+        token: managementKey,
+      }),
+      (data) => data,
+    ),
   deleteSettings: (tenantId: string): Promise<SdkResponse<never>> =>
     transformResponse(
       sdk.httpClient.delete(apiPaths.sso.settings, {
@@ -31,40 +30,40 @@ const withSSOSettings = (sdk: CoreSdk, managementKey?: string) => ({
         token: managementKey,
       }),
     ),
-  configureSettings: deprecate(
-    (
-      tenantId: string,
-      idpURL: string,
-      idpCert: string,
-      entityId: string,
-      redirectURL: string,
-      domains: string[],
-    ): Promise<SdkResponse<never>> =>
-      transformResponse(
-        sdk.httpClient.post(
-          apiPaths.sso.settings,
-          { tenantId, idpURL, entityId, idpCert, redirectURL, domains },
-          { token: managementKey },
-        ),
+  /**
+   * @deprecated  Use configureSAMLSettings instead
+   */
+  configureSettings: (
+    tenantId: string,
+    idpURL: string,
+    idpCert: string,
+    entityId: string,
+    redirectURL: string,
+    domains: string[],
+  ): Promise<SdkResponse<never>> =>
+    transformResponse(
+      sdk.httpClient.post(
+        apiPaths.sso.settings,
+        { tenantId, idpURL, entityId, idpCert, redirectURL, domains },
+        { token: managementKey },
       ),
-    'configureSettings is deprecated, please use configureSAMLSettings instead ',
-  ),
-  configureMetadata: deprecate(
-    (
-      tenantId: string,
-      idpMetadataURL: string,
-      redirectURL: string,
-      domains: string[],
-    ): Promise<SdkResponse<never>> =>
-      transformResponse(
-        sdk.httpClient.post(
-          apiPaths.sso.metadata,
-          { tenantId, idpMetadataURL, redirectURL, domains },
-          { token: managementKey },
-        ),
+    ),
+  /**
+   * @deprecated  Use configureSAMLByMetadata instead
+   */
+  configureMetadata: (
+    tenantId: string,
+    idpMetadataURL: string,
+    redirectURL: string,
+    domains: string[],
+  ): Promise<SdkResponse<never>> =>
+    transformResponse(
+      sdk.httpClient.post(
+        apiPaths.sso.metadata,
+        { tenantId, idpMetadataURL, redirectURL, domains },
+        { token: managementKey },
       ),
-    'configureMetadata is deprecated, please use configureSAMLByMetadata instead',
-  ),
+    ),
   configureMapping: (
     tenantId: string,
     roleMappings?: RoleMappings,

--- a/lib/management/user.ts
+++ b/lib/management/user.ts
@@ -452,7 +452,7 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
     /**
      * Search all users. Results can be filtered according to tenants and/or
      * roles, and also paginated used the limit and page parameters.
-     * @deprecated use search instead
+     * @deprecated Use search instead
      * @param tenantIds optional list of tenant IDs to filter by
      * @param roles optional list of roles to filter by
      * @param limit optionally limit the response, leave out for default limit

--- a/lib/management/user.ts
+++ b/lib/management/user.ts
@@ -5,7 +5,6 @@ import {
   UserResponse,
   LoginOptions,
 } from '@descope/core-js-sdk';
-import { deprecate } from 'util';
 import {
   ProviderTokenResponse,
   AssociatedTenant,
@@ -453,6 +452,7 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
     /**
      * Search all users. Results can be filtered according to tenants and/or
      * roles, and also paginated used the limit and page parameters.
+     * @deprecated use search instead
      * @param tenantIds optional list of tenant IDs to filter by
      * @param roles optional list of roles to filter by
      * @param limit optionally limit the response, leave out for default limit
@@ -461,41 +461,37 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
      * @param withTestUser optionally include test users in search
      * @returns An array of UserResponse found by the query
      */
-
-    searchAll: deprecate(
-      (
-        tenantIds?: string[],
-        roles?: string[],
-        limit?: number,
-        page?: number,
-        testUsersOnly?: boolean,
-        withTestUser?: boolean,
-        customAttributes?: Record<string, AttributesTypes>,
-        statuses?: UserStatus[],
-        emails?: string[],
-        phones?: string[],
-      ): Promise<SdkResponse<UserResponse[]>> =>
-        transformResponse<MultipleUsersResponse, UserResponse[]>(
-          sdk.httpClient.post(
-            apiPaths.user.search,
-            {
-              tenantIds,
-              roleNames: roles,
-              limit,
-              page,
-              testUsersOnly,
-              withTestUser,
-              customAttributes,
-              statuses,
-              emails,
-              phones,
-            },
-            { token: managementKey },
-          ),
-          (data) => data.users,
+    searchAll: (
+      tenantIds?: string[],
+      roles?: string[],
+      limit?: number,
+      page?: number,
+      testUsersOnly?: boolean,
+      withTestUser?: boolean,
+      customAttributes?: Record<string, AttributesTypes>,
+      statuses?: UserStatus[],
+      emails?: string[],
+      phones?: string[],
+    ): Promise<SdkResponse<UserResponse[]>> =>
+      transformResponse<MultipleUsersResponse, UserResponse[]>(
+        sdk.httpClient.post(
+          apiPaths.user.search,
+          {
+            tenantIds,
+            roleNames: roles,
+            limit,
+            page,
+            testUsersOnly,
+            withTestUser,
+            customAttributes,
+            statuses,
+            emails,
+            phones,
+          },
+          { token: managementKey },
         ),
-      'searchAll is deprecated please use search() instead',
-    ),
+        (data) => data.users,
+      ),
     /**
      * Search all users. Results can be filtered according to tenants roles and more,
      * Pagination is also available using the limit and page parameters.


### PR DESCRIPTION

## Description
replace deprecated with jsdocs `@deprecated` which vscode (and webstorm) support OOTB:
![image](https://github.com/descope/node-sdk/assets/10514677/5ad126a0-f605-4db3-af1a-4a377a58ef6c)


some other IDEs (atom for example) may require dedicted plugin 
