### PR TITLE
Add version bump to publish-next

### DIFF
--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -27,10 +27,16 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - name: Get Short SHA
         run: echo "SHORT_SHA=`echo ${{ github.sha }} | cut -c1-8`" >> $GITHUB_ENV
+      - name: Automated Version Bump
+        id: version-bump
+        uses: phips28/gh-action-bump-version@master
+        with:
+          skip-push: 'true'
+          tag-suffix: '-next'
       - name: Get Next Version
         run: |
           current_date=$(date +'%Y%m%d')
-          echo "NEW_VERSION=0.0.0-next-${SHORT_SHA}-${current_date}" >> $GITHUB_ENV
+          echo "NEW_VERSION=${{ steps.version-bump.outputs.newTag }}-${SHORT_SHA}-${current_date}" >> $GITHUB_ENV
       - name: Use Next Version
         run: |
           git config --global user.email "info@descope.com"


### PR DESCRIPTION
## Related Issues
https://github.com/descope/etc/issues/2384

## Description
Add version bump to publish-next in order to allow Renovate to update versions when using `next` tag
Works on a forked version
<img width="729" alt="Screenshot 2024-05-09 at 15 19 16" src="https://github.com/descope/node-sdk/assets/6897892/ae01c990-ee3a-4848-8bb4-785062f00935">


