### PR TITLE
override refresh

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -75,6 +75,9 @@ const nodeSdk = ({ managementKey, publicKey, ...config }: NodeSdkArgs) => {
   const sdk = {
     ...coreSdk,
 
+    // Overrides core-sdk refresh, because the core-sdk exposes queryParams, which is for internal use only
+    refresh: async (token?: string) => coreSdk.refresh(token),
+
     /**
      * Provides various APIs for managing a Descope project programmatically. A management key must
      * be provided as an argument when initializing the SDK to use these APIs. Management keys can be

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.6.9",
       "license": "MIT",
       "dependencies": {
-        "@descope/core-js-sdk": "2.23.4",
+        "@descope/core-js-sdk": "2.24.3",
         "cross-fetch": "^4.0.0",
         "jose": "5.2.2",
         "tslib": "^2.0.0"
@@ -607,10 +607,9 @@
       }
     },
     "node_modules/@descope/core-js-sdk": {
-      "version": "2.23.4",
-      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.23.4.tgz",
-      "integrity": "sha512-3YZxsnGLsYtRE1WPQQlIsEEh86bEEGIe1ey7zGU1qsAkBG7z8in9jIFk0Sn6iOkq5G1tXwanYchY3CDjNbf+9g==",
-      "license": "MIT",
+      "version": "2.24.3",
+      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.24.3.tgz",
+      "integrity": "sha512-NqK57zXgKozIqCyjxhu7l4Mg6zPYOB7uxiZKnY3zpO2rOAiaSWZPg5dVrXtaDMJcBbHYsIY97LYfunMD3V/eiw==",
       "dependencies": {
         "jwt-decode": "3.1.2"
       }

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "typescript": "^4.6.4"
   },
   "dependencies": {
-    "@descope/core-js-sdk": "2.23.4",
+    "@descope/core-js-sdk": "2.24.3",
     "cross-fetch": "^4.0.0",
     "jose": "5.2.2",
     "tslib": "^2.0.0"


### PR DESCRIPTION
## Related Issues

https://github.com/descope/etc/issues/2862

## Description

override refresh because the core-sdk exposes queryParams, which is for internal use only
