### PR TITLE
Expose additional errors on invite batch

### DIFF
--- a/lib/management/types.ts
+++ b/lib/management/types.ts
@@ -535,6 +535,7 @@ export type UserFailedResponse = {
 export type InviteBatchResponse = {
   createdUsers: UserResponse[];
   failedUsers: UserFailedResponse[];
+  additionalErrors: Record<string, string>;
 };
 
 /**


### PR DESCRIPTION
So we can see which users failed on the invite sent and which not
