### PR TITLE
Allow updating jwt expiry via SDK

### DIFF
--- a/lib/management/jwt.test.ts
+++ b/lib/management/jwt.test.ts
@@ -28,13 +28,17 @@ describe('Management JWT', () => {
       };
       mockHttpClient.post.mockResolvedValue(httpResponse);
 
-      const resp: SdkResponse<UpdateJWTResponse> = await management.jwt.update('jwt', {
-        foo: 'bar',
-      });
+      const resp: SdkResponse<UpdateJWTResponse> = await management.jwt.update(
+        'jwt',
+        {
+          foo: 'bar',
+        },
+        4,
+      );
 
       expect(mockHttpClient.post).toHaveBeenCalledWith(
         apiPaths.jwt.update,
-        { jwt: 'jwt', customClaims: { foo: 'bar' } },
+        { jwt: 'jwt', customClaims: { foo: 'bar' }, refreshDuration: 4 },
         { token: 'key' },
       );
 

--- a/lib/management/jwt.ts
+++ b/lib/management/jwt.ts
@@ -7,9 +7,14 @@ const withJWT = (sdk: CoreSdk, managementKey?: string) => ({
   update: (
     jwt: string,
     customClaims?: Record<string, any>,
+    refreshDuration?: number,
   ): Promise<SdkResponse<UpdateJWTResponse>> =>
     transformResponse(
-      sdk.httpClient.post(apiPaths.jwt.update, { jwt, customClaims }, { token: managementKey }),
+      sdk.httpClient.post(
+        apiPaths.jwt.update,
+        { jwt, customClaims, refreshDuration },
+        { token: managementKey },
+      ),
     ),
   impersonate: (
     impersonatorId: string,


### PR DESCRIPTION
Supported as part of jwt update flow
+test
fixes https://github.com/descope/etc/issues/8900
