### PR TITLE
handle error response from descope

### DIFF
--- a/lib/index.test.ts
+++ b/lib/index.test.ts
@@ -272,8 +272,21 @@ describe('sdk', () => {
       await expect(sdk.exchangeAccessKey('key')).rejects.toThrow('could not exchange access key');
       expect(spyExchange).toHaveBeenCalledWith('key', undefined);
     });
+    it('should fail when getting an error response from the serve', async () => {
+      const spyExchange = jest.spyOn(sdk.accessKey, 'exchange').mockResolvedValueOnce({
+        ok: false,
+        error: {
+          errorMessage: 'error-1',
+        },
+      } as SdkResponse<ExchangeAccessKeyResponse>);
+      await expect(sdk.exchangeAccessKey('key')).rejects.toThrow(
+        'could not exchange access key - error-1',
+      );
+      expect(spyExchange).toHaveBeenCalledWith('key', undefined);
+    });
     it('should fail when the session token the server returns is invalid', async () => {
       const spyExchange = jest.spyOn(sdk.accessKey, 'exchange').mockResolvedValueOnce({
+        ok: true,
         data: { sessionJwt: expiredToken },
       } as SdkResponse<ExchangeAccessKeyResponse>);
       await expect(sdk.exchangeAccessKey('key')).rejects.toThrow('could not exchange access key');
@@ -281,6 +294,7 @@ describe('sdk', () => {
     });
     it('should return the same session token it got from the server', async () => {
       const spyExchange = jest.spyOn(sdk.accessKey, 'exchange').mockResolvedValueOnce({
+        ok: true,
         data: { sessionJwt: validToken },
       } as SdkResponse<ExchangeAccessKeyResponse>);
       const expected: AuthenticationInfo = {

--- a/lib/index.test.ts
+++ b/lib/index.test.ts
@@ -268,11 +268,11 @@ describe('sdk', () => {
     it('should fail when getting an unexpected response from the server', async () => {
       const spyExchange = jest
         .spyOn(sdk.accessKey, 'exchange')
-        .mockResolvedValueOnce({ data: {} } as SdkResponse<ExchangeAccessKeyResponse>);
+        .mockResolvedValueOnce({ ok: true, data: {} } as SdkResponse<ExchangeAccessKeyResponse>);
       await expect(sdk.exchangeAccessKey('key')).rejects.toThrow('could not exchange access key');
       expect(spyExchange).toHaveBeenCalledWith('key', undefined);
     });
-    it('should fail when getting an error response from the serve', async () => {
+    it('should fail when getting an error response from the server', async () => {
       const spyExchange = jest.spyOn(sdk.accessKey, 'exchange').mockResolvedValueOnce({
         ok: false,
         error: {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -210,6 +210,11 @@ const nodeSdk = ({ managementKey, publicKey, ...config }: NodeSdkArgs) => {
         throw Error(`could not exchange access key - Failed to exchange. Error: ${error}`);
       }
 
+      if (!resp.ok) {
+        logger?.error('failed to exchange access key', resp.error);
+        throw Error(`could not exchange access key - ${resp.error?.errorMessage}`);
+      }
+
       const { sessionJwt } = resp.data;
       if (!sessionJwt) {
         logger?.error('failed to parse exchange access key response');


### PR DESCRIPTION

## Description

handle a case when sdk's `sdk.accessKey.exchange` returns non ok response