### PR TITLE
feat: added authz.whatCanTargetAccessWithRelation to Node SDK

### DIFF
--- a/examples/managementCli/src/index.ts
+++ b/examples/managementCli/src/index.ts
@@ -885,6 +885,30 @@ program
     handleSdkRes(await sdk.management.authz.whatCanTargetAccess(target), option.output);
   });
 
+program
+  .command('authz-target-access-with-relation')
+  .description('Display all relations for the given target with the given relation')
+  .option('-t, --target <target>', 'The target for the relation, e.g. user:123')
+  .option(
+    '-r, --relationDefinition <relationDefinition>',
+    'A relation on a resource, e.g. can_access',
+  )
+  .option(
+    '-n, --namespace <namespace>',
+    'The namespace (type) of the resource in which the relation is defined, e.g. folder',
+  )
+  .option('-o, --output <filename>', 'Output filename')
+  .action(async (option) => {
+    handleSdkRes(
+      await sdk.management.authz.whatCanTargetAccessWithRelation(
+        option.target,
+        option.relationDefinition,
+        option.namespace,
+      ),
+      option.output,
+    );
+  });
+
 // fga
 program
   .command('fga-save-schema')

--- a/examples/managementCli/src/index.ts
+++ b/examples/managementCli/src/index.ts
@@ -888,11 +888,8 @@ program
 program
   .command('authz-target-access-with-relation')
   .description('Display all relations for the given target with the given relation')
-  .option('-t, --target <target>', 'The target for the relation, e.g. user:123')
-  .option(
-    '-r, --relationDefinition <relationDefinition>',
-    'A relation on a resource, e.g. can_access',
-  )
+  .option('-t, --target <target>', 'The target to check resource access for, e.g. user:123')
+  .option('-r, --relationDefinition <relationDefinition>', 'A relation on a resource, e.g. owner')
   .option(
     '-n, --namespace <namespace>',
     'The namespace (type) of the resource in which the relation is defined, e.g. folder',

--- a/lib/management/authz.test.ts
+++ b/lib/management/authz.test.ts
@@ -486,6 +486,35 @@ describe('Management Authz', () => {
     });
   });
 
+  describe('whatCanTargetAccessWithRelation', () => {
+    it('should load the relations for the given target with specific relation definition and namespace', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => mockRelationResponse,
+        clone: () => ({
+          json: () => Promise.resolve(mockRelationResponse),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const resp: SdkResponse<AuthzRelation[]> =
+        await management.authz.whatCanTargetAccessWithRelation('t', 'owner', 'doc');
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        apiPaths.authz.targetWithRelation,
+        { target: 't', relationDefinition: 'owner', namespace: 'doc' },
+        { token: 'key' },
+      );
+      expect(resp).toEqual({
+        code: 200,
+        data: [mockRelation],
+        ok: true,
+        response: httpResponse,
+      });
+    });
+  });
+
   describe('getModified', () => {
     it('should load the resources and targets changes', async () => {
       const httpResponse = {

--- a/lib/management/authz.ts
+++ b/lib/management/authz.ts
@@ -224,6 +224,28 @@ const WithAuthz = (sdk: CoreSdk, managementKey?: string) => ({
       sdk.httpClient.post(apiPaths.authz.targetAll, { target }, { token: managementKey }),
       (data) => data.relations,
     ),
+
+  /**
+   * Return the list of all relations for the given target and relation including derived relations from the schema tree which include the given relation definition in the path.
+   *
+   * @param target The target for the relation, e.g. user:123
+   * @param relationDefinition A relation on a resource, e.g. can_access
+   * @param namespace The namespace (type) of the resource in which the relation is defined, e.g. folder
+   * @returns array of resources that the target can access on relation paths which include the given relation definition
+   */
+  whatCanTargetAccessWithRelation: (
+    target: string,
+    relationDefinition: string,
+    namespace: string,
+  ): Promise<SdkResponse<AuthzRelation[]>> => transformResponse(
+      sdk.httpClient.post(
+        apiPaths.authz.targetWithRelation,
+        { target, relationDefinition, namespace },
+        { token: managementKey },
+      ),
+      (data) => data.resources,
+    ),
+
   /**
    * Return the list of all relations for the given target including derived relations from the schema tree.
    *

--- a/lib/management/authz.ts
+++ b/lib/management/authz.ts
@@ -8,6 +8,7 @@ import {
   AuthzRelation,
   AuthzRelationQuery,
   AuthzModified,
+  AuthzResource,
 } from './types';
 
 const WithAuthz = (sdk: CoreSdk, managementKey?: string) => ({
@@ -226,10 +227,10 @@ const WithAuthz = (sdk: CoreSdk, managementKey?: string) => ({
     ),
 
   /**
-   * Return the list of all relations for the given target and relation including derived relations from the schema tree which include the given relation definition in the path.
+   * Return all resources which the target can access via relation paths that include the given relation definition
    *
-   * @param target The target for the relation, e.g. user:123
-   * @param relationDefinition A relation on a resource, e.g. can_access
+   * @param target The target to check resource access for, e.g. user:123
+   * @param relationDefinition A relation on a resource, e.g. owner
    * @param namespace The namespace (type) of the resource in which the relation is defined, e.g. folder
    * @returns array of resources that the target can access on relation paths which include the given relation definition
    */
@@ -237,13 +238,13 @@ const WithAuthz = (sdk: CoreSdk, managementKey?: string) => ({
     target: string,
     relationDefinition: string,
     namespace: string,
-  ): Promise<SdkResponse<AuthzRelation[]>> => transformResponse(
+  ): Promise<SdkResponse<AuthzResource[]>> => transformResponse(
       sdk.httpClient.post(
         apiPaths.authz.targetWithRelation,
         { target, relationDefinition, namespace },
         { token: managementKey },
       ),
-      (data) => data.resources,
+      (data) => data.resources.map((resource: string) => ({ resource })),
     ),
 
   /**

--- a/lib/management/authz.ts
+++ b/lib/management/authz.ts
@@ -238,7 +238,8 @@ const WithAuthz = (sdk: CoreSdk, managementKey?: string) => ({
     target: string,
     relationDefinition: string,
     namespace: string,
-  ): Promise<SdkResponse<AuthzResource[]>> => transformResponse(
+  ): Promise<SdkResponse<AuthzResource[]>> =>
+    transformResponse(
       sdk.httpClient.post(
         apiPaths.authz.targetWithRelation,
         { target, relationDefinition, namespace },

--- a/lib/management/authz.ts
+++ b/lib/management/authz.ts
@@ -227,7 +227,7 @@ const WithAuthz = (sdk: CoreSdk, managementKey?: string) => ({
     ),
 
   /**
-   * Return all resources which the target can access via relation paths that include the given relation definition
+   * Return all resources which the target can access via relation paths that end with the given relation definition
    *
    * @param target The target to check resource access for, e.g. user:123
    * @param relationDefinition A relation on a resource, e.g. owner

--- a/lib/management/paths.ts
+++ b/lib/management/paths.ts
@@ -144,6 +144,7 @@ export default {
     resource: '/v1/mgmt/authz/re/resource',
     targets: '/v1/mgmt/authz/re/targets',
     targetAll: '/v1/mgmt/authz/re/targetall',
+    targetWithRelation: '/v1/mgmt/authz/re/targetwithrelation',
     getModified: '/v1/mgmt/authz/getmodified',
   },
   fga: {

--- a/lib/management/types.ts
+++ b/lib/management/types.ts
@@ -661,6 +661,10 @@ export type AuthzUserQuery = {
   customAttributes?: Record<string, any>;
 };
 
+export type AuthzResource = {
+  resource: string;
+};
+
 /**
  * AuthzRelation defines a relation between resource and target
  */


### PR DESCRIPTION
## Related Issues

Fixes: https://github.com/descope/etc/issues/9537

## Related PRs:
Can be merged, but depends on fixing https://github.com/descope/authzservice/pull/1122 so that the server can accept the requests

## Description

Adding the missing `whatCanTargetAccessWithRelation` method to the Node SDK, per clients request.
This method already exists in the Go SDK.

## Must

- [x] Tests
- [ ] Documentation (if applicable)
