### PR TITLE
feat: Allow custom refresh token duration

### DIFF
--- a/lib/management/jwt.ts
+++ b/lib/management/jwt.ts
@@ -24,11 +24,12 @@ const withJWT = (sdk: CoreSdk, managementKey?: string) => ({
     validateConsent: boolean,
     customClaims?: Record<string, any>,
     selectedTenant?: string,
+    refreshDuration?: number,
   ): Promise<SdkResponse<UpdateJWTResponse>> =>
     transformResponse(
       sdk.httpClient.post(
         apiPaths.jwt.impersonate,
-        { impersonatorId, loginId, validateConsent, customClaims, selectedTenant },
+        { impersonatorId, loginId, validateConsent, customClaims, selectedTenant, refreshDuration },
         { token: managementKey },
       ),
     ),
@@ -67,11 +68,12 @@ const withJWT = (sdk: CoreSdk, managementKey?: string) => ({
   anonymous: (
     customClaims?: Record<string, any>,
     selectedTenant?: string,
+    refreshDuration?: number,
   ): Promise<SdkResponse<AnonymousJWTResponse>> =>
     transformResponse(
       sdk.httpClient.post(
         apiPaths.jwt.anonymous,
-        { customClaims, selectedTenant },
+        { customClaims, selectedTenant, refreshDuration },
         { token: managementKey },
       ),
     ),

--- a/lib/management/types.ts
+++ b/lib/management/types.ts
@@ -812,11 +812,13 @@ export type CheckResponseRelation = {
 // should have the type of loginoptions expect templateId and templateOptions
 export type MgmtLoginOptions = Omit<LoginOptions, 'templateId' | 'templateOptions'> & {
   jwt?: string;
+  refreshDuration?: number;
 };
 
 export type MgmtSignUpOptions = {
   // we can replace this with partial `SignUpOptions` from core-js-sdk once its exported
   customClaims?: Record<string, any>;
+  refreshDuration?: number;
 };
 
 export interface UserOptions {


### PR DESCRIPTION
For SDK calls initiated by MGMT SDK
related to https://github.com/descope/etc/issues/10354
