### PR TITLE
[Fix] - typo in tenant enforceSSO attribute name

### DIFF
--- a/lib/management/types.ts
+++ b/lib/management/types.ts
@@ -159,7 +159,7 @@ export type Tenant = {
   customAttributes?: Record<string, string | number | boolean>;
   domains?: string[];
   authType?: 'none' | 'saml' | 'oidc';
-  forceSSO?: boolean;
+  enforceSSO?: boolean;
   disabled?: boolean;
 };
 


### PR DESCRIPTION
## Description
typo in name due to attribute name change
