### PR TITLE
fix: return refresh JWT

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,8 @@ The implementation can defer according to your implementation. See our [examples
 If Roles & Permissions are used, validate them immediately after validating the session. See the [next section](#roles--permission-validation)
 for more information.
 
+Note: if refresh token rotation is enabled in Descope - `refreshSession` / `validateAndRefreshSession` will return a new refresh token, and the old one will be invalidated.
+
 #### Session Validation Using Middleware
 
 Alternatively, you can create a simple middleware function that internally uses the `validateSession` function.

--- a/lib/index.test.ts
+++ b/lib/index.test.ts
@@ -181,7 +181,20 @@ describe('sdk', () => {
         data: { sessionJwt: validToken },
       } as SdkResponse<JWTResponse>);
 
-      await expect(sdk.refreshSession(validToken)).resolves.toHaveProperty('jwt', validToken);
+      const res = await sdk.refreshSession(validToken);
+      expect(res.jwt).toBe(validToken);
+      expect(res.refreshJwt).toBeFalsy();
+      expect(spyRefresh).toHaveBeenCalledWith(validToken);
+    });
+    it('should return refresh jwt when refresh call returns it', async () => {
+      const spyRefresh = jest.spyOn(sdk, 'refresh').mockResolvedValueOnce({
+        ok: true,
+        data: { sessionJwt: validToken, refreshJwt: 'refresh-jwt' },
+      } as SdkResponse<JWTResponse>);
+
+      const res = await sdk.refreshSession(validToken);
+      expect(res.jwt).toBe(validToken);
+      expect(res.refreshJwt).toBe('refresh-jwt');
       expect(spyRefresh).toHaveBeenCalledWith(validToken);
     });
     it('should fail when refresh returns an error', async () => {
@@ -235,10 +248,19 @@ describe('sdk', () => {
         ok: true,
         data: { sessionJwt: validToken },
       } as SdkResponse<JWTResponse>);
-      await expect(sdk.validateAndRefreshSession('', validToken)).resolves.toHaveProperty(
-        'jwt',
-        validToken,
-      );
+      const res = await sdk.validateAndRefreshSession('', validToken);
+      expect(res.jwt).toBe(validToken);
+      expect(res.refreshJwt).toBeFalsy();
+      expect(spyRefresh).toHaveBeenCalledWith(validToken);
+    });
+    it('should refresh session and return refresh jwt when refresh call returns it', async () => {
+      const spyRefresh = jest.spyOn(sdk, 'refresh').mockResolvedValueOnce({
+        ok: true,
+        data: { sessionJwt: validToken, refreshJwt: 'refresh-jwt' },
+      } as SdkResponse<JWTResponse>);
+      const res = await sdk.validateAndRefreshSession('', validToken);
+      expect(res.jwt).toBe(validToken);
+      expect(res.refreshJwt).toBe('refresh-jwt');
       expect(spyRefresh).toHaveBeenCalledWith(validToken);
     });
     it('should return the session token when it is valid', async () => {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -17,6 +17,10 @@ export interface AuthenticationInfo {
   cookies?: string[];
 }
 
+export interface RefreshAuthenticationInfo extends AuthenticationInfo {
+  refreshJwt?: string;
+}
+
 /** Descope core SDK type */
 export type CreateCoreSdk = typeof createSdk;
 export type CoreSdkConfig = Head<Parameters<CreateCoreSdk>>;


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/11024

## Description
consider a case where refresh return `refreshJwt`