### PR TITLE
Fix: Correct typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1103,7 +1103,7 @@ const updatedJWTRes = await descopeClient.management.jwt.update('original-jwt', 
 });
 ```
 
-Generate a JWT for a user, simulating a signin request.
+Generate a JWT for a user, simulating a sign in request.
 
 ```typescript
 const res = await descopeClient.management.jwt.signIn('dummy');


### PR DESCRIPTION
Hey, our tool caught a typo in your repository.

Also, here is your site's error report: https://triplechecker.com/s/gyj8rv/descope.com

Hope it's helpful!
