### PR TITLE
Add tenant role IDs and names to user search request

### DIFF
--- a/lib/management/user.test.ts
+++ b/lib/management/user.test.ts
@@ -838,6 +838,8 @@ describe('Management User', () => {
         fromModifiedTime: now,
         toModifiedTime: now,
         sort: [{ field: 'aa', desc: true }, { field: 'bb' }],
+        tenantRoleIds: { tenant1: ['roleA', 'roleB'] },
+        tenantRoleNames: { tenant2: ['admin', 'user'] },
       });
 
       expect(mockHttpClient.post).toHaveBeenCalledWith(
@@ -857,6 +859,8 @@ describe('Management User', () => {
           withTestUser: true,
           testUsersOnly: true,
           sort: [{ field: 'aa', desc: true }, { field: 'bb' }],
+          tenantRoleIds: { tenant1: { values: ['roleA', 'roleB'] } },
+          tenantRoleNames: { tenant2: { values: ['admin', 'user'] } },
         },
         { token: 'key' },
       );
@@ -895,6 +899,8 @@ describe('Management User', () => {
         fromModifiedTime: now,
         toModifiedTime: now,
         sort: [{ field: 'aa', desc: true }, { field: 'bb' }],
+        tenantRoleIds: { tenant1: ['roleA', 'roleB'] },
+        tenantRoleNames: { tenant2: ['admin', 'user'] },
       });
 
       expect(mockHttpClient.post).toHaveBeenCalledWith(
@@ -912,6 +918,8 @@ describe('Management User', () => {
           fromModifiedTime: now,
           toModifiedTime: now,
           sort: [{ field: 'aa', desc: true }, { field: 'bb' }],
+          tenantRoleIds: { tenant1: { values: ['roleA', 'roleB'] } },
+          tenantRoleNames: { tenant2: { values: ['admin', 'user'] } },
         },
         { token: 'key' },
       );

--- a/lib/management/user.ts
+++ b/lib/management/user.ts
@@ -48,6 +48,8 @@ type SearchRequest = {
   toCreatedTime?: number; // Search users created before this time (epoch in milliseconds)
   fromModifiedTime?: number; // Search users modified after this time (epoch in milliseconds)
   toModifiedTime?: number; // Search users modified before this time (epoch in milliseconds)
+  tenantRoleIds?: Record<string, string[]>;
+  tenantRoleNames?: Record<string, string[]>;
 };
 
 type SingleUserResponse = {
@@ -57,6 +59,17 @@ type SingleUserResponse = {
 type MultipleUsersResponse = {
   users: UserResponse[];
 };
+
+function mapToValuesObject(
+  input: Record<string, string[]> | undefined,
+): Record<string, { values: string[] }> | undefined {
+  if (!input || Object.keys(input).length === 0) {
+    return undefined;
+  }
+  return Object.fromEntries(
+    Object.entries(input).map(([key, value]) => [key, { values: value }]),
+  ) as Record<string, { values: string[] }>;
+}
 
 const withUser = (sdk: CoreSdk, managementKey?: string) => {
   /* Create User */
@@ -587,6 +600,8 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
             testUsersOnly: true,
             roleNames: searchReq.roles,
             roles: undefined,
+            tenantRoleIds: mapToValuesObject(searchReq.tenantRoleIds),
+            tenantRoleNames: mapToValuesObject(searchReq.tenantRoleNames),
           },
           { token: managementKey },
         ),
@@ -600,6 +615,8 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
             ...searchReq,
             roleNames: searchReq.roles,
             roles: undefined,
+            tenantRoleIds: mapToValuesObject(searchReq.tenantRoleIds),
+            tenantRoleNames: mapToValuesObject(searchReq.tenantRoleNames),
           },
           { token: managementKey },
         ),


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/11275

## Description

Added tenantRoleIds and tenantRoleNames user search parameters to search for users with tenants and roles.

## Must

- [ ] Tests
- [ ] Documentation (if applicable)
