### PR TITLE
Use separate http clients for auth and management

### DIFF
--- a/examples/managementCli/package-lock.json
+++ b/examples/managementCli/package-lock.json
@@ -25,10 +25,10 @@
     },
     "../..": {
       "name": "@descope/node-sdk",
-      "version": "1.7.8",
+      "version": "1.7.12",
       "license": "MIT",
       "dependencies": {
-        "@descope/core-js-sdk": "2.44.3",
+        "@descope/core-js-sdk": "2.45.0",
         "cross-fetch": "^4.0.0",
         "jose": "5.2.2",
         "tslib": "^2.0.0"
@@ -1644,7 +1644,7 @@
     "@descope/node-sdk": {
       "version": "file:../..",
       "requires": {
-        "@descope/core-js-sdk": "2.44.3",
+        "@descope/core-js-sdk": "2.45.0",
         "@rollup/plugin-commonjs": "^28.0.0",
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^13.3.0",

--- a/examples/managementCli/src/index.ts
+++ b/examples/managementCli/src/index.ts
@@ -3,7 +3,6 @@ import DescopeClient, { SdkResponse } from '@descope/node-sdk';
 import { config } from 'dotenv';
 import { writeFileSync, readFileSync } from 'fs';
 import { Command } from 'commander';
-import { UserResponse } from '@descope/core-js-sdk';
 
 config();
 

--- a/lib/index.test.ts
+++ b/lib/index.test.ts
@@ -509,9 +509,11 @@ describe('sdk', () => {
     it('should add descope headers to request', async () => {
       jest.resetModules();
       const createCoreJs = jest.fn();
+      const createHttpClient = jest.fn();
       jest.doMock('@descope/core-js-sdk', () => ({
         __esModule: true,
         default: createCoreJs,
+        createHttpClient,
         wrapWith: (sdkInstance: object) => sdkInstance,
         addHooksToConfig: (config, hooks) => {
           // eslint-disable-next-line no-param-reassign
@@ -542,10 +544,12 @@ describe('sdk', () => {
     it('should add auth management key to request when there is no token', async () => {
       jest.resetModules();
       const createCoreJs = jest.fn();
+      const createHttpClient = jest.fn();
 
       jest.doMock('@descope/core-js-sdk', () => ({
         __esModule: true,
         default: createCoreJs,
+        createHttpClient,
         wrapWith: (sdkInstance: object) => sdkInstance,
         addHooksToConfig: (config, hooks) => {
           // eslint-disable-next-line no-param-reassign
@@ -581,10 +585,12 @@ describe('sdk', () => {
     it('should add auth management key to request when there is token', async () => {
       jest.resetModules();
       const createCoreJs = jest.fn();
+      const createHttpClient = jest.fn();
 
       jest.doMock('@descope/core-js-sdk', () => ({
         __esModule: true,
         default: createCoreJs,
+        createHttpClient,
         wrapWith: (sdkInstance: object) => sdkInstance,
         addHooksToConfig: (config, hooks) => {
           // eslint-disable-next-line no-param-reassign
@@ -612,11 +618,13 @@ describe('sdk', () => {
     it('should merge before request hooks if they are defined', async () => {
       jest.resetModules();
       const createCoreJs = jest.fn();
+      const createHttpClient = jest.fn();
       const existingHook = jest.fn((config) => ({ ...config, customField: 'test' }));
 
       jest.doMock('@descope/core-js-sdk', () => ({
         __esModule: true,
         default: createCoreJs,
+        createHttpClient,
         wrapWith: (sdkInstance: object) => sdkInstance,
         addHooksToConfig: (config, hooks) => {
           // eslint-disable-next-line no-param-reassign

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,6 +4,9 @@ import createSdk, {
   SdkResponse,
   JWTResponse as CoreJWTResponse,
   wrapWith,
+  createHttpClient,
+  CreateHttpClientConfig,
+  RequestConfig,
 } from '@descope/core-js-sdk';
 import { JWK, JWTHeaderParameters, KeyLike, errors, importJWK, jwtVerify } from 'jose';
 import {
@@ -38,19 +41,24 @@ type NodeSdkArgs = Parameters<typeof createSdk>[0] & {
 };
 
 const nodeSdk = ({ authManagementKey, managementKey, publicKey, ...config }: NodeSdkArgs) => {
-  const coreSdk = createSdk({
+  const nodeHeaders = {
+    'x-descope-sdk-name': 'nodejs',
+    'x-descope-sdk-node-version': process?.versions?.node || '',
+    'x-descope-sdk-version': BUILD_VERSION,
+  };
+
+  const authSdkConfig = {
     fetch,
     ...config,
     baseHeaders: {
       ...config.baseHeaders,
-      'x-descope-sdk-name': 'nodejs',
-      'x-descope-sdk-node-version': process?.versions?.node || '',
-      'x-descope-sdk-version': BUILD_VERSION,
+      ...nodeHeaders,
     },
     hooks: {
       ...config.hooks,
       beforeRequest: [
-        (requestConfig) => {
+        // auth requests append the auth management key if provided
+        (requestConfig: RequestConfig) => {
           if (authManagementKey) {
             // eslint-disable-next-line no-param-reassign
             requestConfig.token = !requestConfig.token
@@ -62,7 +70,8 @@ const nodeSdk = ({ authManagementKey, managementKey, publicKey, ...config }: Nod
         },
       ].concat(config.hooks?.beforeRequest || []),
     },
-  });
+  };
+  const coreSdk = createSdk(authSdkConfig);
 
   const { projectId, logger } = config;
 
@@ -98,7 +107,29 @@ const nodeSdk = ({ authManagementKey, managementKey, publicKey, ...config }: Nod
     );
   };
 
-  const management = withManagement(coreSdk, managementKey);
+  const mgmtSdkConfig = {
+    fetch,
+    ...config,
+    baseConfig: {
+      baseHeaders: {
+        ...config.baseHeaders,
+        ...nodeHeaders,
+      },
+    },
+    hooks: {
+      ...config.hooks,
+      beforeRequest: [
+        // management requests always use the management key as the token
+        (requestConfig: RequestConfig) => {
+          // eslint-disable-next-line no-param-reassign
+          requestConfig.token = managementKey;
+          return requestConfig;
+        },
+      ].concat(config.hooks?.beforeRequest || []),
+    },
+  };
+  const mgmtHttpClient = createHttpClient(mgmtSdkConfig);
+  const management = withManagement(mgmtHttpClient);
 
   const sdk = {
     ...coreSdk,

--- a/lib/management/accesskey.test.ts
+++ b/lib/management/accesskey.test.ts
@@ -1,10 +1,10 @@
 import { SdkResponse } from '@descope/core-js-sdk';
 import withManagement from '.';
 import apiPaths from './paths';
-import { mockCoreSdk, mockHttpClient } from './testutils';
+import { mockHttpClient, resetMockHttpClient } from './testutils';
 import { CreatedAccessKeyResponse, AccessKey } from './types';
 
-const management = withManagement(mockCoreSdk, 'key');
+const management = withManagement(mockHttpClient);
 
 const mockAccessKeyResponse = {
   id: 'ak1',
@@ -23,7 +23,7 @@ const mockMgmtAccessKeysResponse = {
 describe('Management Access Keys', () => {
   afterEach(() => {
     jest.clearAllMocks();
-    mockHttpClient.reset();
+    resetMockHttpClient();
   });
 
   describe('create', () => {
@@ -53,20 +53,16 @@ describe('Management Access Keys', () => {
         ['10.0.0.1', '192.168.1.0/24'],
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.accessKey.create,
-        {
-          name: 'foo',
-          expireTime: 123456789,
-          roleNames: ['r1', 'r2'],
-          keyTenants: null,
-          userId: 'uid',
-          customClaims: { k1: 'v1' },
-          description: 'hey',
-          permittedIps: ['10.0.0.1', '192.168.1.0/24'],
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.accessKey.create, {
+        name: 'foo',
+        expireTime: 123456789,
+        roleNames: ['r1', 'r2'],
+        keyTenants: null,
+        userId: 'uid',
+        customClaims: { k1: 'v1' },
+        description: 'hey',
+        permittedIps: ['10.0.0.1', '192.168.1.0/24'],
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -93,7 +89,6 @@ describe('Management Access Keys', () => {
 
       expect(mockHttpClient.get).toHaveBeenCalledWith(apiPaths.accessKey.load, {
         queryParams: { id: 'id' },
-        token: 'key',
       });
 
       expect(resp).toEqual({
@@ -119,11 +114,9 @@ describe('Management Access Keys', () => {
 
       const resp: SdkResponse<AccessKey[]> = await management.accessKey.searchAll(['t1']);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.accessKey.search,
-        { tenantIds: ['t1'] },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.accessKey.search, {
+        tenantIds: ['t1'],
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -156,19 +149,15 @@ describe('Management Access Keys', () => {
         ['1.2.3.4'],
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.accessKey.update,
-        {
-          id: 'id',
-          name: 'name',
-          description: 'description',
-          roleNames: ['r1', 'r2'],
-          keyTenants: undefined,
-          customClaims: { k1: 'v1' },
-          permittedIps: ['1.2.3.4'],
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.accessKey.update, {
+        id: 'id',
+        name: 'name',
+        description: 'description',
+        roleNames: ['r1', 'r2'],
+        keyTenants: undefined,
+        customClaims: { k1: 'v1' },
+        permittedIps: ['1.2.3.4'],
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -193,11 +182,7 @@ describe('Management Access Keys', () => {
 
       const resp: SdkResponse<AccessKey> = await management.accessKey.deactivate('id');
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.accessKey.deactivate,
-        { id: 'id' },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.accessKey.deactivate, { id: 'id' });
 
       expect(resp).toEqual({
         code: 200,
@@ -222,11 +207,7 @@ describe('Management Access Keys', () => {
 
       const resp: SdkResponse<AccessKey> = await management.accessKey.activate('id');
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.accessKey.activate,
-        { id: 'id' },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.accessKey.activate, { id: 'id' });
 
       expect(resp).toEqual({
         code: 200,
@@ -251,11 +232,7 @@ describe('Management Access Keys', () => {
 
       const resp: SdkResponse<AccessKey> = await management.accessKey.delete('id');
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.accessKey.delete,
-        { id: 'id' },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.accessKey.delete, { id: 'id' });
 
       expect(resp).toEqual({
         code: 200,

--- a/lib/management/accesskey.ts
+++ b/lib/management/accesskey.ts
@@ -1,5 +1,4 @@
-import { SdkResponse, transformResponse } from '@descope/core-js-sdk';
-import { CoreSdk } from '../types';
+import { SdkResponse, transformResponse, HttpClient } from '@descope/core-js-sdk';
 import apiPaths from './paths';
 import { AccessKey, AssociatedTenant, CreatedAccessKeyResponse } from './types';
 
@@ -11,7 +10,7 @@ type MultipleKeysResponse = {
   keys: AccessKey[];
 };
 
-const withAccessKey = (sdk: CoreSdk, managementKey?: string) => ({
+const withAccessKey = (httpClient: HttpClient) => ({
   /**
    * Create a new access key for a project.
    * @param name Access key name
@@ -35,20 +34,16 @@ const withAccessKey = (sdk: CoreSdk, managementKey?: string) => ({
     permittedIps?: string[],
   ): Promise<SdkResponse<CreatedAccessKeyResponse>> =>
     transformResponse(
-      sdk.httpClient.post(
-        apiPaths.accessKey.create,
-        {
-          name,
-          expireTime,
-          roleNames: roles,
-          keyTenants: tenants,
-          userId,
-          customClaims,
-          description,
-          permittedIps,
-        },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.accessKey.create, {
+        name,
+        expireTime,
+        roleNames: roles,
+        keyTenants: tenants,
+        userId,
+        customClaims,
+        description,
+        permittedIps,
+      }),
     ),
   /**
    * Load an access key.
@@ -57,9 +52,8 @@ const withAccessKey = (sdk: CoreSdk, managementKey?: string) => ({
    */
   load: (id: string): Promise<SdkResponse<AccessKey>> =>
     transformResponse<SingleKeyResponse, AccessKey>(
-      sdk.httpClient.get(apiPaths.accessKey.load, {
+      httpClient.get(apiPaths.accessKey.load, {
         queryParams: { id },
-        token: managementKey,
       }),
       (data) => data.key,
     ),
@@ -70,7 +64,7 @@ const withAccessKey = (sdk: CoreSdk, managementKey?: string) => ({
    */
   searchAll: (tenantIds?: string[]): Promise<SdkResponse<AccessKey[]>> =>
     transformResponse<MultipleKeysResponse, AccessKey[]>(
-      sdk.httpClient.post(apiPaths.accessKey.search, { tenantIds }, { token: managementKey }),
+      httpClient.post(apiPaths.accessKey.search, { tenantIds }),
       (data) => data.keys,
     ),
   /**
@@ -94,19 +88,15 @@ const withAccessKey = (sdk: CoreSdk, managementKey?: string) => ({
     permittedIps?: string[],
   ): Promise<SdkResponse<AccessKey>> =>
     transformResponse<SingleKeyResponse, AccessKey>(
-      sdk.httpClient.post(
-        apiPaths.accessKey.update,
-        {
-          id,
-          name,
-          description,
-          roleNames: roles,
-          keyTenants: tenants,
-          customClaims,
-          permittedIps,
-        },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.accessKey.update, {
+        id,
+        name,
+        description,
+        roleNames: roles,
+        keyTenants: tenants,
+        customClaims,
+        permittedIps,
+      }),
       (data) => data.key,
     ),
   /**
@@ -115,25 +105,19 @@ const withAccessKey = (sdk: CoreSdk, managementKey?: string) => ({
    * @param id Access key ID to deactivate
    */
   deactivate: (id: string): Promise<SdkResponse<never>> =>
-    transformResponse(
-      sdk.httpClient.post(apiPaths.accessKey.deactivate, { id }, { token: managementKey }),
-    ),
+    transformResponse(httpClient.post(apiPaths.accessKey.deactivate, { id })),
   /**
    * Activate an access key. Only deactivated access keys can be activated again.
    * @param id Access key ID to activate
    */
   activate: (id: string): Promise<SdkResponse<never>> =>
-    transformResponse(
-      sdk.httpClient.post(apiPaths.accessKey.activate, { id }, { token: managementKey }),
-    ),
+    transformResponse(httpClient.post(apiPaths.accessKey.activate, { id })),
   /**
    * Delete an access key. IMPORTANT: This cannot be undone. Use carefully.
    * @param id Access key ID to delete
    */
   delete: (id: string): Promise<SdkResponse<never>> =>
-    transformResponse(
-      sdk.httpClient.post(apiPaths.accessKey.delete, { id }, { token: managementKey }),
-    ),
+    transformResponse(httpClient.post(apiPaths.accessKey.delete, { id })),
 });
 
 export default withAccessKey;

--- a/lib/management/audit.test.ts
+++ b/lib/management/audit.test.ts
@@ -1,10 +1,10 @@
 import { SdkResponse } from '@descope/core-js-sdk';
 import withManagement from '.';
 import apiPaths from './paths';
-import { mockCoreSdk, mockHttpClient } from './testutils';
+import { mockHttpClient, resetMockHttpClient } from './testutils';
 import { AuditRecord } from './types';
 
-const management = withManagement(mockCoreSdk, 'key');
+const management = withManagement(mockHttpClient);
 
 const mockMgmtAuditRecord = {
   projectId: 'p1',
@@ -25,7 +25,7 @@ const mockMgmtAuditSearchResponse = {
 describe('Management Audit', () => {
   afterEach(() => {
     jest.clearAllMocks();
-    mockHttpClient.reset();
+    resetMockHttpClient();
   });
 
   describe('search', () => {
@@ -42,11 +42,9 @@ describe('Management Audit', () => {
 
       const resp: SdkResponse<AuditRecord[]> = await management.audit.search({ loginIds: ['id1'] });
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.audit.search,
-        { externalIds: ['id1'] },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.audit.search, {
+        externalIds: ['id1'],
+      });
       const res = {
         ...mockMgmtAuditRecord,
         loginIds: mockMgmtAuditRecord.externalIds,
@@ -83,18 +81,14 @@ describe('Management Audit', () => {
         data: { a: 'b' },
       });
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.audit.createEvent,
-        {
-          userId: 'userId',
-          type: 'info',
-          action: 'action',
-          actorId: 'actorId',
-          tenantId: 'tenantId',
-          data: { a: 'b' },
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.audit.createEvent, {
+        userId: 'userId',
+        type: 'info',
+        action: 'action',
+        actorId: 'actorId',
+        tenantId: 'tenantId',
+        data: { a: 'b' },
+      });
       expect(resp).toEqual({
         code: 200,
         data: {},

--- a/lib/management/audit.ts
+++ b/lib/management/audit.ts
@@ -1,9 +1,8 @@
-import { SdkResponse, transformResponse } from '@descope/core-js-sdk';
-import { CoreSdk } from '../types';
+import { SdkResponse, transformResponse, HttpClient } from '@descope/core-js-sdk';
 import apiPaths from './paths';
 import { AuditSearchOptions, AuditRecord, AuditCreateOptions } from './types';
 
-const WithAudit = (sdk: CoreSdk, managementKey?: string) => ({
+const WithAudit = (httpClient: HttpClient) => ({
   /**
    * Search the audit trail for up to last 30 days based on given optional parameters
    * @param searchOptions to filter which audit records to return
@@ -12,18 +11,16 @@ const WithAudit = (sdk: CoreSdk, managementKey?: string) => ({
   search: (searchOptions: AuditSearchOptions): Promise<SdkResponse<AuditRecord[]>> => {
     const body = { ...searchOptions, externalIds: searchOptions.loginIds };
     delete body.loginIds;
-    return transformResponse(
-      sdk.httpClient.post(apiPaths.audit.search, body, { token: managementKey }),
-      (data) =>
-        data?.audits.map((a) => {
-          const res = {
-            ...a,
-            occurred: parseFloat(a.occurred),
-            loginIds: a.externalIds,
-          };
-          delete res.externalIds;
-          return res;
-        }),
+    return transformResponse(httpClient.post(apiPaths.audit.search, body), (data) =>
+      data?.audits.map((a) => {
+        const res = {
+          ...a,
+          occurred: parseFloat(a.occurred),
+          loginIds: a.externalIds,
+        };
+        delete res.externalIds;
+        return res;
+      }),
     );
   },
   /**
@@ -33,9 +30,7 @@ const WithAudit = (sdk: CoreSdk, managementKey?: string) => ({
    */
   createEvent: (createOptions: AuditCreateOptions): Promise<SdkResponse<never>> => {
     const body = { ...createOptions };
-    return transformResponse(
-      sdk.httpClient.post(apiPaths.audit.createEvent, body, { token: managementKey }),
-    );
+    return transformResponse(httpClient.post(apiPaths.audit.createEvent, body));
   },
 });
 

--- a/lib/management/authz.test.ts
+++ b/lib/management/authz.test.ts
@@ -1,7 +1,7 @@
 import { SdkResponse } from '@descope/core-js-sdk';
 import withManagement from '.';
 import apiPaths from './paths';
-import { mockCoreSdk, mockHttpClient } from './testutils';
+import { mockHttpClient, resetMockHttpClient } from './testutils';
 import {
   AuthzSchema,
   AuthzRelation,
@@ -10,7 +10,7 @@ import {
   AuthzResource,
 } from './types';
 
-const management = withManagement(mockCoreSdk, 'key');
+const management = withManagement(mockHttpClient);
 
 const mockLoadSchema = {
   name: 'mock',
@@ -57,7 +57,7 @@ const mockModified = {
 describe('Management Authz', () => {
   afterEach(() => {
     jest.clearAllMocks();
-    mockHttpClient.reset();
+    resetMockHttpClient();
   });
 
   describe('loadSchema', () => {
@@ -74,11 +74,7 @@ describe('Management Authz', () => {
 
       const resp: SdkResponse<AuthzSchema> = await management.authz.loadSchema();
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.authz.schemaLoad,
-        {},
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.authz.schemaLoad, {});
       expect(resp).toEqual({
         code: 200,
         data: mockLoadSchema,
@@ -102,11 +98,10 @@ describe('Management Authz', () => {
 
       const resp: SdkResponse<never> = await management.authz.saveSchema(mockLoadSchema, true);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.authz.schemaSave,
-        { schema: mockLoadSchema, upgrade: true },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.authz.schemaSave, {
+        schema: mockLoadSchema,
+        upgrade: true,
+      });
       expect(resp).toEqual({
         code: 200,
         data: {},
@@ -130,11 +125,7 @@ describe('Management Authz', () => {
 
       const resp: SdkResponse<never> = await management.authz.deleteSchema();
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.authz.schemaDelete,
-        {},
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.authz.schemaDelete, {});
       expect(resp).toEqual({
         code: 200,
         data: {},
@@ -160,11 +151,9 @@ describe('Management Authz', () => {
         mockLoadSchema.namespaces[0],
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.authz.nsSave,
-        { namespace: mockLoadSchema.namespaces[0] },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.authz.nsSave, {
+        namespace: mockLoadSchema.namespaces[0],
+      });
       expect(resp).toEqual({
         code: 200,
         data: {},
@@ -188,11 +177,10 @@ describe('Management Authz', () => {
 
       const resp: SdkResponse<never> = await management.authz.deleteNamespace('doc');
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.authz.nsDelete,
-        { name: 'doc', schemaName: undefined },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.authz.nsDelete, {
+        name: 'doc',
+        schemaName: undefined,
+      });
       expect(resp).toEqual({
         code: 200,
         data: {},
@@ -219,14 +207,10 @@ describe('Management Authz', () => {
         'owner',
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.authz.rdSave,
-        {
-          relationDefinition: mockLoadSchema.namespaces[0].relationDefinitions[0],
-          namespace: 'owner',
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.authz.rdSave, {
+        relationDefinition: mockLoadSchema.namespaces[0].relationDefinitions[0],
+        namespace: 'owner',
+      });
       expect(resp).toEqual({
         code: 200,
         data: {},
@@ -253,11 +237,11 @@ describe('Management Authz', () => {
         'doc',
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.authz.rdDelete,
-        { name: 'owner', namespace: 'doc', schemaName: undefined },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.authz.rdDelete, {
+        name: 'owner',
+        namespace: 'doc',
+        schemaName: undefined,
+      });
       expect(resp).toEqual({
         code: 200,
         data: {},
@@ -281,13 +265,9 @@ describe('Management Authz', () => {
 
       const resp: SdkResponse<never> = await management.authz.createRelations([mockRelation]);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.authz.reCreate,
-        {
-          relations: [mockRelation],
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.authz.reCreate, {
+        relations: [mockRelation],
+      });
       expect(resp).toEqual({
         code: 200,
         data: {},
@@ -311,11 +291,9 @@ describe('Management Authz', () => {
 
       const resp: SdkResponse<never> = await management.authz.deleteRelationsForResources(['x']);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.authz.reDeleteResources,
-        { resources: ['x'] },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.authz.reDeleteResources, {
+        resources: ['x'],
+      });
       expect(resp).toEqual({
         code: 200,
         data: {},
@@ -344,7 +322,6 @@ describe('Management Authz', () => {
       expect(mockHttpClient.post).toHaveBeenCalledWith(
         apiPaths.authz.reDeleteResourceRelationsForResources,
         { resources: ['x'] },
-        { token: 'key' },
       );
       expect(resp).toEqual({
         code: 200,
@@ -369,11 +346,9 @@ describe('Management Authz', () => {
 
       const resp: SdkResponse<never> = await management.authz.deleteRelationsForIds(['x']);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.authz.reDeleteResources,
-        { resources: ['x'] },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.authz.reDeleteResources, {
+        resources: ['x'],
+      });
       expect(resp).toEqual({
         code: 200,
         data: {},
@@ -397,11 +372,9 @@ describe('Management Authz', () => {
 
       const resp: SdkResponse<never> = await management.authz.deleteRelations([mockRelation]);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.authz.reDelete,
-        { relations: [mockRelation] },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.authz.reDelete, {
+        relations: [mockRelation],
+      });
       expect(resp).toEqual({
         code: 200,
         data: {},
@@ -430,7 +403,6 @@ describe('Management Authz', () => {
       expect(mockHttpClient.post).toHaveBeenCalledWith(
         apiPaths.authz.hasRelations,
         mockRelationsQueryResponse,
-        { token: 'key' },
       );
       expect(resp).toEqual({
         code: 200,
@@ -456,11 +428,11 @@ describe('Management Authz', () => {
 
       const resp: SdkResponse<string[]> = await management.authz.whoCanAccess('r', 'owner', 'doc');
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.authz.who,
-        { resource: 'r', relationDefinition: 'owner', namespace: 'doc' },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.authz.who, {
+        resource: 'r',
+        relationDefinition: 'owner',
+        namespace: 'doc',
+      });
       expect(resp).toEqual({
         code: 200,
         data: ['u1'],
@@ -487,11 +459,10 @@ describe('Management Authz', () => {
         true,
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.authz.resource,
-        { resource: 'r', ignoreTargetSetRelations: true },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.authz.resource, {
+        resource: 'r',
+        ignoreTargetSetRelations: true,
+      });
       expect(resp).toEqual({
         code: 200,
         data: [mockRelation],
@@ -518,11 +489,10 @@ describe('Management Authz', () => {
         true,
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.authz.targets,
-        { targets: ['t'], includeTargetSetRelations: true },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.authz.targets, {
+        targets: ['t'],
+        includeTargetSetRelations: true,
+      });
       expect(resp).toEqual({
         code: 200,
         data: [mockRelation],
@@ -546,11 +516,7 @@ describe('Management Authz', () => {
 
       const resp: SdkResponse<AuthzRelation[]> = await management.authz.whatCanTargetAccess('t');
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.authz.targetAll,
-        { target: 't' },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.authz.targetAll, { target: 't' });
       expect(resp).toEqual({
         code: 200,
         data: [mockRelation],
@@ -579,15 +545,11 @@ describe('Management Authz', () => {
           mockRelation.namespace,
         );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.authz.targetWithRelation,
-        {
-          target: mockRelation.target,
-          relationDefinition: mockRelation.relationDefinition,
-          namespace: mockRelation.namespace,
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.authz.targetWithRelation, {
+        target: mockRelation.target,
+        relationDefinition: mockRelation.relationDefinition,
+        namespace: mockRelation.namespace,
+      });
       expect(resp).toEqual({
         code: 200,
         data: [{ resource: 'roadmap.ppt' }],
@@ -611,11 +573,7 @@ describe('Management Authz', () => {
 
       const resp: SdkResponse<AuthzModified> = await management.authz.getModified(undefined);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.authz.getModified,
-        { since: 0 },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.authz.getModified, { since: 0 });
       expect(resp).toEqual({
         code: 200,
         data: mockModified,

--- a/lib/management/authz.ts
+++ b/lib/management/authz.ts
@@ -1,5 +1,4 @@
-import { SdkResponse, transformResponse } from '@descope/core-js-sdk';
-import { CoreSdk } from '../types';
+import { SdkResponse, transformResponse, HttpClient } from '@descope/core-js-sdk';
 import apiPaths from './paths';
 import {
   AuthzSchema,
@@ -11,7 +10,7 @@ import {
   AuthzResource,
 } from './types';
 
-const WithAuthz = (sdk: CoreSdk, managementKey?: string) => ({
+const WithAuthz = (httpClient: HttpClient) => ({
   /**
    * Save (create or update) the given schema.
    * In case of update, will update only given namespaces and will not delete namespaces unless upgrade flag is true.
@@ -22,28 +21,21 @@ const WithAuthz = (sdk: CoreSdk, managementKey?: string) => ({
    * @returns standard success or failure response
    */
   saveSchema: (schema: AuthzSchema, upgrade: boolean): Promise<SdkResponse<never>> =>
-    transformResponse(
-      sdk.httpClient.post(apiPaths.authz.schemaSave, { schema, upgrade }, { token: managementKey }),
-    ),
+    transformResponse(httpClient.post(apiPaths.authz.schemaSave, { schema, upgrade })),
   /**
    * Delete the schema for the project which will also delete all relations.
    *
    * @returns standard success or failure response
    */
   deleteSchema: (): Promise<SdkResponse<never>> =>
-    transformResponse(
-      sdk.httpClient.post(apiPaths.authz.schemaDelete, {}, { token: managementKey }),
-    ),
+    transformResponse(httpClient.post(apiPaths.authz.schemaDelete, {})),
   /**
    * Load the schema for the project.
    *
    * @returns the schema associated with the project
    */
   loadSchema: (): Promise<SdkResponse<AuthzSchema>> =>
-    transformResponse(
-      sdk.httpClient.post(apiPaths.authz.schemaLoad, {}, { token: managementKey }),
-      (data) => data.schema,
-    ),
+    transformResponse(httpClient.post(apiPaths.authz.schemaLoad, {}), (data) => data.schema),
   /**
    * Save (create or update) the given namespace.
    * Will not delete relation definitions not mentioned in the namespace.
@@ -58,13 +50,7 @@ const WithAuthz = (sdk: CoreSdk, managementKey?: string) => ({
     oldName?: string,
     schemaName?: string,
   ): Promise<SdkResponse<never>> =>
-    transformResponse(
-      sdk.httpClient.post(
-        apiPaths.authz.nsSave,
-        { namespace, oldName, schemaName },
-        { token: managementKey },
-      ),
-    ),
+    transformResponse(httpClient.post(apiPaths.authz.nsSave, { namespace, oldName, schemaName })),
   /**
    * Delete the given namespace.
    * Will also delete the relevant relations.
@@ -74,9 +60,7 @@ const WithAuthz = (sdk: CoreSdk, managementKey?: string) => ({
    * @returns standard success or failure response
    */
   deleteNamespace: (name: string, schemaName?: string): Promise<SdkResponse<never>> =>
-    transformResponse(
-      sdk.httpClient.post(apiPaths.authz.nsDelete, { name, schemaName }, { token: managementKey }),
-    ),
+    transformResponse(httpClient.post(apiPaths.authz.nsDelete, { name, schemaName })),
   /**
    * Save (create or update) the given relation definition.
    *
@@ -93,11 +77,12 @@ const WithAuthz = (sdk: CoreSdk, managementKey?: string) => ({
     schemaName?: string,
   ): Promise<SdkResponse<never>> =>
     transformResponse(
-      sdk.httpClient.post(
-        apiPaths.authz.rdSave,
-        { relationDefinition, namespace, oldName, schemaName },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.authz.rdSave, {
+        relationDefinition,
+        namespace,
+        oldName,
+        schemaName,
+      }),
     ),
   /**
    * Delete the given relation definition.
@@ -113,13 +98,7 @@ const WithAuthz = (sdk: CoreSdk, managementKey?: string) => ({
     namespace: string,
     schemaName?: string,
   ): Promise<SdkResponse<never>> =>
-    transformResponse(
-      sdk.httpClient.post(
-        apiPaths.authz.rdDelete,
-        { name, namespace, schemaName },
-        { token: managementKey },
-      ),
-    ),
+    transformResponse(httpClient.post(apiPaths.authz.rdDelete, { name, namespace, schemaName })),
   /**
    * Create the given relations.
    *
@@ -127,9 +106,7 @@ const WithAuthz = (sdk: CoreSdk, managementKey?: string) => ({
    * @returns standard success or failure response
    */
   createRelations: (relations: AuthzRelation[]): Promise<SdkResponse<never>> =>
-    transformResponse(
-      sdk.httpClient.post(apiPaths.authz.reCreate, { relations }, { token: managementKey }),
-    ),
+    transformResponse(httpClient.post(apiPaths.authz.reCreate, { relations })),
   /**
    * Delete the given relations.
    *
@@ -137,9 +114,7 @@ const WithAuthz = (sdk: CoreSdk, managementKey?: string) => ({
    * @returns standard success or failure response
    */
   deleteRelations: (relations: AuthzRelation[]): Promise<SdkResponse<never>> =>
-    transformResponse(
-      sdk.httpClient.post(apiPaths.authz.reDelete, { relations }, { token: managementKey }),
-    ),
+    transformResponse(httpClient.post(apiPaths.authz.reDelete, { relations })),
   /**
    * @deprecated use `deleteRelationsForIds` instead for better clarity
    *
@@ -149,13 +124,7 @@ const WithAuthz = (sdk: CoreSdk, managementKey?: string) => ({
    * @returns standard success or failure response
    */
   deleteRelationsForResources: (resources: string[]): Promise<SdkResponse<never>> =>
-    transformResponse(
-      sdk.httpClient.post(
-        apiPaths.authz.reDeleteResources,
-        { resources },
-        { token: managementKey },
-      ),
-    ),
+    transformResponse(httpClient.post(apiPaths.authz.reDeleteResources, { resources })),
   /**
    *
    * Delete any relations with matching resourceIds
@@ -165,11 +134,7 @@ const WithAuthz = (sdk: CoreSdk, managementKey?: string) => ({
    */
   deleteResourceRelationsForResources: (resources: string[]): Promise<SdkResponse<never>> =>
     transformResponse(
-      sdk.httpClient.post(
-        apiPaths.authz.reDeleteResourceRelationsForResources,
-        { resources },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.authz.reDeleteResourceRelationsForResources, { resources }),
     ),
   /**
    * Delete any relations with matching resourceIds OR targetIds
@@ -178,13 +143,7 @@ const WithAuthz = (sdk: CoreSdk, managementKey?: string) => ({
    * @returns standard success or failure response
    */
   deleteRelationsForIds: (ids: string[]): Promise<SdkResponse<never>> =>
-    transformResponse(
-      sdk.httpClient.post(
-        apiPaths.authz.reDeleteResources,
-        { resources: ids },
-        { token: managementKey },
-      ),
-    ),
+    transformResponse(httpClient.post(apiPaths.authz.reDeleteResources, { resources: ids })),
   /**
    * Query relations to see what relations exists.
    *
@@ -195,11 +154,7 @@ const WithAuthz = (sdk: CoreSdk, managementKey?: string) => ({
     relationQueries: AuthzRelationQuery[],
   ): Promise<SdkResponse<AuthzRelationQuery[]>> =>
     transformResponse(
-      sdk.httpClient.post(
-        apiPaths.authz.hasRelations,
-        { relationQueries },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.authz.hasRelations, { relationQueries }),
       (data) => data.relationQueries,
     ),
   /**
@@ -216,11 +171,7 @@ const WithAuthz = (sdk: CoreSdk, managementKey?: string) => ({
     namespace: string,
   ): Promise<SdkResponse<string[]>> =>
     transformResponse(
-      sdk.httpClient.post(
-        apiPaths.authz.who,
-        { resource, relationDefinition, namespace },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.authz.who, { resource, relationDefinition, namespace }),
       (data) => data.targets,
     ),
   /**
@@ -235,11 +186,7 @@ const WithAuthz = (sdk: CoreSdk, managementKey?: string) => ({
     ignoreTargetSetRelations = false,
   ): Promise<SdkResponse<AuthzRelation[]>> =>
     transformResponse(
-      sdk.httpClient.post(
-        apiPaths.authz.resource,
-        { resource, ignoreTargetSetRelations },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.authz.resource, { resource, ignoreTargetSetRelations }),
       (data) => data.relations,
     ),
   /**
@@ -254,11 +201,7 @@ const WithAuthz = (sdk: CoreSdk, managementKey?: string) => ({
     includeTargetSetRelations = false,
   ): Promise<SdkResponse<AuthzRelation[]>> =>
     transformResponse(
-      sdk.httpClient.post(
-        apiPaths.authz.targets,
-        { targets, includeTargetSetRelations },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.authz.targets, { targets, includeTargetSetRelations }),
       (data) => data.relations,
     ),
   /**
@@ -269,7 +212,7 @@ const WithAuthz = (sdk: CoreSdk, managementKey?: string) => ({
    */
   whatCanTargetAccess: (target: string): Promise<SdkResponse<AuthzRelation[]>> =>
     transformResponse(
-      sdk.httpClient.post(apiPaths.authz.targetAll, { target }, { token: managementKey }),
+      httpClient.post(apiPaths.authz.targetAll, { target }),
       (data) => data.relations,
     ),
 
@@ -287,11 +230,7 @@ const WithAuthz = (sdk: CoreSdk, managementKey?: string) => ({
     namespace: string,
   ): Promise<SdkResponse<AuthzResource[]>> =>
     transformResponse(
-      sdk.httpClient.post(
-        apiPaths.authz.targetWithRelation,
-        { target, relationDefinition, namespace },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.authz.targetWithRelation, { target, relationDefinition, namespace }),
       (data) => data.resources.map((resource: string) => ({ resource })),
     ),
 
@@ -303,11 +242,7 @@ const WithAuthz = (sdk: CoreSdk, managementKey?: string) => ({
    */
   getModified: (since: Date): Promise<SdkResponse<AuthzModified>> =>
     transformResponse(
-      sdk.httpClient.post(
-        apiPaths.authz.getModified,
-        { since: since ? since.getTime() : 0 },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.authz.getModified, { since: since ? since.getTime() : 0 }),
       (data) => data as AuthzModified,
     ),
 });

--- a/lib/management/fga.test.ts
+++ b/lib/management/fga.test.ts
@@ -1,6 +1,6 @@
 import WithFGA from './fga';
 import apiPaths from './paths';
-import { mockCoreSdk, mockHttpClient } from './testutils';
+import { mockHttpClient, resetMockHttpClient } from './testutils';
 import { FGAResourceIdentifier, FGAResourceDetails } from './types';
 
 const emptySuccessResponse = {
@@ -43,27 +43,21 @@ const mockCheckResponse = {
 describe('Management FGA', () => {
   afterEach(() => {
     jest.clearAllMocks();
-    mockHttpClient.reset();
+    resetMockHttpClient();
   });
   describe('saveSchema', () => {
     it('should save the schema', async () => {
       const schema = { dsl: 'schema' };
-      const response = await WithFGA(mockCoreSdk).saveSchema(schema);
-      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.fga.schema, schema, {
-        token: undefined,
-      });
+      const response = await WithFGA(mockHttpClient).saveSchema(schema);
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.fga.schema, schema);
       expect(response).toEqual(emptySuccessResponse);
     });
   });
 
   describe('deleteSchema', () => {
     it('should delete the schema', async () => {
-      const response = await WithFGA(mockCoreSdk).deleteSchema();
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.authz.schemaDelete,
-        {},
-        { token: undefined },
-      );
+      const response = await WithFGA(mockHttpClient).deleteSchema();
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.authz.schemaDelete, {});
       expect(response).toEqual(emptySuccessResponse);
     });
   });
@@ -71,12 +65,10 @@ describe('Management FGA', () => {
   describe('createRelations', () => {
     it('should create the relations', async () => {
       const relations = [relation1];
-      const response = await WithFGA(mockCoreSdk).createRelations(relations);
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.fga.relations,
-        { tuples: relations },
-        { token: undefined },
-      );
+      const response = await WithFGA(mockHttpClient).createRelations(relations);
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.fga.relations, {
+        tuples: relations,
+      });
       expect(response).toEqual(emptySuccessResponse);
     });
   });
@@ -84,22 +76,18 @@ describe('Management FGA', () => {
   describe('deleteRelations', () => {
     it('should delete the relations', async () => {
       const relations = [relation1];
-      const response = await WithFGA(mockCoreSdk).deleteRelations(relations);
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.fga.deleteRelations,
-        { tuples: relations },
-        { token: undefined },
-      );
+      const response = await WithFGA(mockHttpClient).deleteRelations(relations);
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.fga.deleteRelations, {
+        tuples: relations,
+      });
       expect(response).toEqual(emptySuccessResponse);
     });
   });
 
   describe('deleteAllRelations', () => {
     it('should delete all relations', async () => {
-      const response = await WithFGA(mockCoreSdk).deleteAllRelations();
-      expect(mockHttpClient.delete).toHaveBeenCalledWith(apiPaths.fga.relations, {
-        token: undefined,
-      });
+      const response = await WithFGA(mockHttpClient).deleteAllRelations();
+      expect(mockHttpClient.delete).toHaveBeenCalledWith(apiPaths.fga.relations);
       expect(response).toEqual(emptySuccessResponse);
     });
   });
@@ -116,12 +104,8 @@ describe('Management FGA', () => {
         status: 200,
       };
       mockHttpClient.post.mockResolvedValue(httpResponse);
-      const response = await WithFGA(mockCoreSdk).check(relations);
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.fga.check,
-        { tuples: relations },
-        { token: undefined },
-      );
+      const response = await WithFGA(mockHttpClient).check(relations);
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.fga.check, { tuples: relations });
       expect(response).toEqual({
         code: 200,
         data: mockCheckResponseRelations,
@@ -144,12 +128,10 @@ describe('Management FGA', () => {
         status: 200,
       };
       mockHttpClient.post.mockResolvedValue(httpResponse);
-      const response = await WithFGA(mockCoreSdk).loadResourcesDetails(ids);
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.fga.resourcesLoad,
-        { resourceIdentifiers: ids },
-        { token: undefined },
-      );
+      const response = await WithFGA(mockHttpClient).loadResourcesDetails(ids);
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.fga.resourcesLoad, {
+        resourceIdentifiers: ids,
+      });
       expect(response).toEqual({
         code: 200,
         data: mockDetails,
@@ -162,7 +144,7 @@ describe('Management FGA', () => {
       const ids: FGAResourceIdentifier[] = [{ resourceId: 'r1', resourceType: 'type1' }];
       const httpResponse = { ok: false, status: 400 };
       mockHttpClient.post.mockResolvedValue(httpResponse);
-      await expect(WithFGA(mockCoreSdk).loadResourcesDetails(ids)).rejects.toThrow();
+      await expect(WithFGA(mockHttpClient).loadResourcesDetails(ids)).rejects.toThrow();
     });
   });
 
@@ -171,12 +153,10 @@ describe('Management FGA', () => {
       const details: FGAResourceDetails[] = [
         { resourceId: 'r1', resourceType: 'type1', displayName: 'Name1' },
       ];
-      const response = await WithFGA(mockCoreSdk).saveResourcesDetails(details);
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.fga.resourcesSave,
-        { resourcesDetails: details },
-        { token: undefined },
-      );
+      const response = await WithFGA(mockHttpClient).saveResourcesDetails(details);
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.fga.resourcesSave, {
+        resourcesDetails: details,
+      });
       expect(response).toEqual(emptySuccessResponse);
     });
 
@@ -184,7 +164,7 @@ describe('Management FGA', () => {
       const details = [{ resourceId: 'r1', resourceType: 'type1', displayName: 'Name1' }];
       const httpResponse = { ok: false, status: 400 };
       mockHttpClient.post.mockResolvedValue(httpResponse);
-      await expect(WithFGA(mockCoreSdk).saveResourcesDetails(details)).rejects.toThrow();
+      await expect(WithFGA(mockHttpClient).saveResourcesDetails(details)).rejects.toThrow();
     });
   });
 });

--- a/lib/management/fga.ts
+++ b/lib/management/fga.ts
@@ -1,5 +1,4 @@
-import { SdkResponse, transformResponse } from '@descope/core-js-sdk';
-import { CoreSdk } from '../types';
+import { SdkResponse, transformResponse, HttpClient } from '@descope/core-js-sdk';
 import apiPaths from './paths';
 import {
   CheckResponseRelation,
@@ -9,7 +8,7 @@ import {
   FGAResourceIdentifier,
 } from './types';
 
-const WithFGA = (sdk: CoreSdk, managementKey?: string) => ({
+const WithFGA = (httpClient: HttpClient) => ({
   /**
    * Save (create or update) the given schema.
    * In case of update, will update only given namespaces and will not delete namespaces unless upgrade flag is true.
@@ -18,16 +17,14 @@ const WithFGA = (sdk: CoreSdk, managementKey?: string) => ({
    * @returns standard success or failure response
    */
   saveSchema: (schema: FGASchema): Promise<SdkResponse<never>> =>
-    transformResponse(sdk.httpClient.post(apiPaths.fga.schema, schema, { token: managementKey })),
+    transformResponse(httpClient.post(apiPaths.fga.schema, schema)),
   /**
    * Delete the schema for the project which will also delete all relations.
    *
    * @returns standard success or failure response
    */
   deleteSchema: (): Promise<SdkResponse<never>> =>
-    transformResponse(
-      sdk.httpClient.post(apiPaths.authz.schemaDelete, {}, { token: managementKey }),
-    ),
+    transformResponse(httpClient.post(apiPaths.authz.schemaDelete, {})),
   /**
    * Create the given relations.
    *
@@ -35,9 +32,7 @@ const WithFGA = (sdk: CoreSdk, managementKey?: string) => ({
    * @returns standard success or failure response
    */
   createRelations: (relations: FGARelation[]): Promise<SdkResponse<never>> =>
-    transformResponse(
-      sdk.httpClient.post(apiPaths.fga.relations, { tuples: relations }, { token: managementKey }),
-    ),
+    transformResponse(httpClient.post(apiPaths.fga.relations, { tuples: relations })),
 
   /**
    * Delete the given relations.
@@ -48,13 +43,7 @@ const WithFGA = (sdk: CoreSdk, managementKey?: string) => ({
    */
 
   deleteRelations: (relations: FGARelation[]): Promise<SdkResponse<never>> =>
-    transformResponse(
-      sdk.httpClient.post(
-        apiPaths.fga.deleteRelations,
-        { tuples: relations },
-        { token: managementKey },
-      ),
-    ),
+    transformResponse(httpClient.post(apiPaths.fga.deleteRelations, { tuples: relations })),
 
   /**
    * Check if the given relations exist.
@@ -67,7 +56,7 @@ const WithFGA = (sdk: CoreSdk, managementKey?: string) => ({
    */
   check: (relations: FGARelation[]): Promise<SdkResponse<CheckResponseRelation[]>> =>
     transformResponse(
-      sdk.httpClient.post(apiPaths.fga.check, { tuples: relations }, { token: managementKey }),
+      httpClient.post(apiPaths.fga.check, { tuples: relations }),
       (data) => data.tuples,
     ),
 
@@ -79,11 +68,7 @@ const WithFGA = (sdk: CoreSdk, managementKey?: string) => ({
     resourceIdentifiers: FGAResourceIdentifier[],
   ): Promise<SdkResponse<FGAResourceDetails[]>> =>
     transformResponse(
-      sdk.httpClient.post(
-        apiPaths.fga.resourcesLoad,
-        { resourceIdentifiers },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.fga.resourcesLoad, { resourceIdentifiers }),
       (data) => data.resourcesDetails,
     ),
 
@@ -92,13 +77,7 @@ const WithFGA = (sdk: CoreSdk, managementKey?: string) => ({
    * @param resourcesDetails the resources details to save
    */
   saveResourcesDetails: (resourcesDetails: FGAResourceDetails[]): Promise<SdkResponse<never>> =>
-    transformResponse(
-      sdk.httpClient.post(
-        apiPaths.fga.resourcesSave,
-        { resourcesDetails },
-        { token: managementKey },
-      ),
-    ),
+    transformResponse(httpClient.post(apiPaths.fga.resourcesSave, { resourcesDetails })),
 
   /**
    * Delete all relations.
@@ -106,7 +85,7 @@ const WithFGA = (sdk: CoreSdk, managementKey?: string) => ({
    * @returns standard success or failure response
    */
   deleteAllRelations: (): Promise<SdkResponse<never>> =>
-    transformResponse(sdk.httpClient.delete(apiPaths.fga.relations, { token: managementKey })),
+    transformResponse(httpClient.delete(apiPaths.fga.relations)),
 });
 
 export default WithFGA;

--- a/lib/management/flow.test.ts
+++ b/lib/management/flow.test.ts
@@ -1,7 +1,7 @@
 import { SdkResponse } from '@descope/core-js-sdk';
 import withManagement from '.';
 import apiPaths from './paths';
-import { mockCoreSdk, mockHttpClient } from './testutils';
+import { mockHttpClient, resetMockHttpClient } from './testutils';
 import {
   FlowResponse,
   FlowsResponse,
@@ -12,7 +12,7 @@ import {
   FlowMetadata,
 } from './types';
 
-const management = withManagement(mockCoreSdk, 'key');
+const management = withManagement(mockHttpClient);
 
 const mockFlow: Flow = {
   dsl: {},
@@ -59,7 +59,7 @@ const mockThemeResponse: ThemeResponse = {
 describe('Management flow', () => {
   afterEach(() => {
     jest.clearAllMocks();
-    mockHttpClient.reset();
+    resetMockHttpClient();
   });
 
   describe('list', () => {
@@ -76,7 +76,7 @@ describe('Management flow', () => {
 
       const resp: SdkResponse<FlowsResponse> = await management.flow.list();
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.flow.list, {}, { token: 'key' });
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.flow.list, {});
 
       expect(resp).toEqual({
         code: 200,
@@ -101,11 +101,9 @@ describe('Management flow', () => {
 
       const resp: SdkResponse<FlowsResponse> = await management.flow.delete(['flow-1', 'flow-2']);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.flow.delete,
-        { ids: ['flow-1', 'flow-2'] },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.flow.delete, {
+        ids: ['flow-1', 'flow-2'],
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -131,11 +129,7 @@ describe('Management flow', () => {
       const id = 'flow-id';
       const resp: SdkResponse<FlowResponse> = await management.flow.export(id);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.flow.export,
-        { flowId: id },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.flow.export, { flowId: id });
 
       expect(resp).toEqual({
         code: 200,
@@ -163,11 +157,11 @@ describe('Management flow', () => {
         mockScreen,
       ]);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.flow.import,
-        { flowId: id, screens: [mockScreen], flow: mockFlow },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.flow.import, {
+        flowId: id,
+        screens: [mockScreen],
+        flow: mockFlow,
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -193,11 +187,10 @@ describe('Management flow', () => {
       const id = 'flow-id';
       const resp = await management.flow.run(id);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.flow.run,
-        { flowId: id, options: undefined },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.flow.run, {
+        flowId: id,
+        options: undefined,
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -222,11 +215,7 @@ describe('Management flow', () => {
       const options = { input: { userId: '123' }, preview: true };
       const resp = await management.flow.run(id, options);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.flow.run,
-        { flowId: id, options },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.flow.run, { flowId: id, options });
 
       expect(resp).toEqual({
         code: 200,
@@ -241,7 +230,7 @@ describe('Management flow', () => {
 describe('Management theme', () => {
   afterEach(() => {
     jest.clearAllMocks();
-    mockHttpClient.reset();
+    resetMockHttpClient();
   });
 
   describe('export', () => {
@@ -258,7 +247,7 @@ describe('Management theme', () => {
 
       const resp: SdkResponse<ThemeResponse> = await management.theme.export();
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.theme.export, {}, { token: 'key' });
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.theme.export, {});
 
       expect(resp).toEqual({
         code: 200,
@@ -283,11 +272,7 @@ describe('Management theme', () => {
 
       const resp: SdkResponse<ThemeResponse> = await management.theme.import(mockTheme);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.theme.import,
-        { theme: mockTheme },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.theme.import, { theme: mockTheme });
 
       expect(resp).toEqual({
         code: 200,

--- a/lib/management/flow.ts
+++ b/lib/management/flow.ts
@@ -1,5 +1,4 @@
-import { SdkResponse, transformResponse } from '@descope/core-js-sdk';
-import { CoreSdk } from '../types';
+import { SdkResponse, transformResponse, HttpClient } from '@descope/core-js-sdk';
 import apiPaths from './paths';
 import {
   FlowResponse,
@@ -10,31 +9,21 @@ import {
   RunManagementFlowResponse,
 } from './types';
 
-const WithFlow = (sdk: CoreSdk, managementKey?: string) => ({
+const WithFlow = (httpClient: HttpClient) => ({
   list: (): Promise<SdkResponse<FlowsResponse>> =>
-    transformResponse(sdk.httpClient.post(apiPaths.flow.list, {}, { token: managementKey })),
+    transformResponse(httpClient.post(apiPaths.flow.list, {})),
   delete: (flowIds: string[]): Promise<SdkResponse<never>> =>
-    transformResponse(
-      sdk.httpClient.post(apiPaths.flow.delete, { ids: flowIds }, { token: managementKey }),
-    ),
+    transformResponse(httpClient.post(apiPaths.flow.delete, { ids: flowIds })),
   export: (flowId: string): Promise<SdkResponse<FlowResponse>> =>
-    transformResponse(
-      sdk.httpClient.post(apiPaths.flow.export, { flowId }, { token: managementKey }),
-    ),
+    transformResponse(httpClient.post(apiPaths.flow.export, { flowId })),
   import: (flowId: string, flow: Flow, screens?: Screen[]): Promise<SdkResponse<FlowResponse>> =>
-    transformResponse(
-      sdk.httpClient.post(
-        apiPaths.flow.import,
-        { flowId, flow, screens },
-        { token: managementKey },
-      ),
-    ),
+    transformResponse(httpClient.post(apiPaths.flow.import, { flowId, flow, screens })),
   run: (
     flowId: string,
     options?: ManagementFlowOptions,
   ): Promise<SdkResponse<RunManagementFlowResponse['output']>> =>
     transformResponse(
-      sdk.httpClient.post(apiPaths.flow.run, { flowId, options }, { token: managementKey }),
+      httpClient.post(apiPaths.flow.run, { flowId, options }),
       (data) => (data as RunManagementFlowResponse)?.output,
     ),
 });

--- a/lib/management/group.test.ts
+++ b/lib/management/group.test.ts
@@ -1,10 +1,10 @@
 import { SdkResponse } from '@descope/core-js-sdk';
 import withManagement from '.';
 import apiPaths from './paths';
-import { mockCoreSdk, mockHttpClient } from './testutils';
+import { mockHttpClient, resetMockHttpClient } from './testutils';
 import { Group } from './types';
 
-const management = withManagement(mockCoreSdk, 'key');
+const management = withManagement(mockHttpClient);
 
 const mockGroups = [
   { id: 'id1', display: 'display1', members: [] },
@@ -15,7 +15,7 @@ const mockGroups = [
 describe('Management group', () => {
   afterEach(() => {
     jest.clearAllMocks();
-    mockHttpClient.reset();
+    resetMockHttpClient();
   });
 
   describe('loadAllGroups', () => {
@@ -33,11 +33,7 @@ describe('Management group', () => {
       const tenantId = 'tenant-id';
       const resp: SdkResponse<Group[]> = await management.group.loadAllGroups(tenantId);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.group.loadAllGroups,
-        { tenantId },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.group.loadAllGroups, { tenantId });
 
       expect(resp).toEqual({
         code: 200,
@@ -69,11 +65,11 @@ describe('Management group', () => {
         loginIds,
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.group.loadAllGroupsForMember,
-        { tenantId, userIds, loginIds },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.group.loadAllGroupsForMember, {
+        tenantId,
+        userIds,
+        loginIds,
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -103,11 +99,10 @@ describe('Management group', () => {
         groupId,
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.group.loadAllGroupMembers,
-        { tenantId, groupId },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.group.loadAllGroupMembers, {
+        tenantId,
+        groupId,
+      });
 
       expect(resp).toEqual({
         code: 200,

--- a/lib/management/group.ts
+++ b/lib/management/group.ts
@@ -1,18 +1,15 @@
-import { SdkResponse, transformResponse } from '@descope/core-js-sdk';
-import { CoreSdk } from '../types';
+import { SdkResponse, transformResponse, HttpClient } from '@descope/core-js-sdk';
 import apiPaths from './paths';
 import { Group } from './types';
 
-const withGroup = (sdk: CoreSdk, managementKey?: string) => ({
+const withGroup = (httpClient: HttpClient) => ({
   /**
    * Load all groups for a specific tenant id.
    * @param tenantId Tenant ID to load groups from.
    * @returns Group[] list of groups
    */
   loadAllGroups: (tenantId: string): Promise<SdkResponse<Group[]>> =>
-    transformResponse<Group[]>(
-      sdk.httpClient.post(apiPaths.group.loadAllGroups, { tenantId }, { token: managementKey }),
-    ),
+    transformResponse<Group[]>(httpClient.post(apiPaths.group.loadAllGroups, { tenantId })),
 
   /**
    * Load all groups for the provided user IDs or login IDs.
@@ -27,11 +24,7 @@ const withGroup = (sdk: CoreSdk, managementKey?: string) => ({
     loginIds: string[],
   ): Promise<SdkResponse<Group[]>> =>
     transformResponse<Group[]>(
-      sdk.httpClient.post(
-        apiPaths.group.loadAllGroupsForMember,
-        { tenantId, loginIds, userIds },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.group.loadAllGroupsForMember, { tenantId, loginIds, userIds }),
     ),
 
   /**
@@ -42,11 +35,7 @@ const withGroup = (sdk: CoreSdk, managementKey?: string) => ({
    */
   loadAllGroupMembers: (tenantId: string, groupId: string): Promise<SdkResponse<Group[]>> =>
     transformResponse<Group[]>(
-      sdk.httpClient.post(
-        apiPaths.group.loadAllGroupMembers,
-        { tenantId, groupId },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.group.loadAllGroupMembers, { tenantId, groupId }),
     ),
 });
 

--- a/lib/management/inboundapplication.test.ts
+++ b/lib/management/inboundapplication.test.ts
@@ -7,9 +7,9 @@ import {
   InboundApplicationConsent,
   InboundApplicationSecretResponse,
 } from './types';
-import { mockCoreSdk, mockHttpClient } from './testutils';
+import { mockHttpClient, resetMockHttpClient } from './testutils';
 
-const management = withManagement(mockCoreSdk, 'key');
+const management = withManagement(mockHttpClient);
 
 const mockInboundApplicationCreateResponse = {
   id: 'foo',
@@ -70,7 +70,7 @@ const mockInboundApplicationConsentsResponse = {
 describe('Management InboundApplication', () => {
   afterEach(() => {
     jest.clearAllMocks();
-    mockHttpClient.reset();
+    resetMockHttpClient();
   });
 
   describe('createInboundApplication', () => {
@@ -98,21 +98,17 @@ describe('Management InboundApplication', () => {
           description: 'test',
         });
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.inboundApplication.create,
-        {
-          name: 'name',
-          loginPageUrl: 'http://dummy.com',
-          permissionsScopes: [
-            {
-              name: 'scope1',
-              description: 'scope1 description',
-            },
-          ],
-          description: 'test',
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.inboundApplication.create, {
+        name: 'name',
+        loginPageUrl: 'http://dummy.com',
+        permissionsScopes: [
+          {
+            name: 'scope1',
+            description: 'scope1 description',
+          },
+        ],
+        description: 'test',
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -145,19 +141,15 @@ describe('Management InboundApplication', () => {
         loginPageUrl: 'http://dummy.com',
       });
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.inboundApplication.update,
-        {
-          id: 'app1',
-          name: 'name',
-          permissionsScopes: [],
-          logo: 'logo',
-          description: 'desc',
-          approvedCallbackUrls: ['test.com'],
-          loginPageUrl: 'http://dummy.com',
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.inboundApplication.update, {
+        id: 'app1',
+        name: 'name',
+        permissionsScopes: [],
+        logo: 'logo',
+        description: 'desc',
+        approvedCallbackUrls: ['test.com'],
+        loginPageUrl: 'http://dummy.com',
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -188,17 +180,13 @@ describe('Management InboundApplication', () => {
         permissionsScopes: [],
       });
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.inboundApplication.patch,
-        {
-          id: 'app1',
-          permissionsScopes: [],
-          logo: 'logo',
-          description: 'desc',
-          loginPageUrl: 'http://dummy.com',
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.inboundApplication.patch, {
+        id: 'app1',
+        permissionsScopes: [],
+        logo: 'logo',
+        description: 'desc',
+        loginPageUrl: 'http://dummy.com',
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -223,11 +211,9 @@ describe('Management InboundApplication', () => {
 
       const resp = await management.inboundApplication.deleteApplication('app1');
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.inboundApplication.delete,
-        { id: 'app1' },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.inboundApplication.delete, {
+        id: 'app1',
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -255,7 +241,6 @@ describe('Management InboundApplication', () => {
 
       expect(mockHttpClient.get).toHaveBeenCalledWith(apiPaths.inboundApplication.load, {
         queryParams: { id: mockInboundApplications[0].id },
-        token: 'key',
       });
 
       expect(resp).toEqual({
@@ -286,7 +271,6 @@ describe('Management InboundApplication', () => {
 
       expect(mockHttpClient.get).toHaveBeenCalledWith(apiPaths.inboundApplication.secret, {
         queryParams: { id: mockInboundApplications[0].id },
-        token: 'key',
       });
 
       expect(resp).toEqual({
@@ -314,11 +298,9 @@ describe('Management InboundApplication', () => {
 
       const resp = await management.inboundApplication.rotateApplicationSecret('app1');
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.inboundApplication.rotate,
-        { id: 'app1' },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.inboundApplication.rotate, {
+        id: 'app1',
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -344,9 +326,7 @@ describe('Management InboundApplication', () => {
       const resp: SdkResponse<InboundApplication[]> =
         await management.inboundApplication.loadAllApplications();
 
-      expect(mockHttpClient.get).toHaveBeenCalledWith(apiPaths.inboundApplication.loadAll, {
-        token: 'key',
-      });
+      expect(mockHttpClient.get).toHaveBeenCalledWith(apiPaths.inboundApplication.loadAll, {});
 
       expect(resp).toEqual({
         code: 200,
@@ -377,18 +357,12 @@ describe('Management InboundApplication', () => {
           page: 1,
         });
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.inboundApplicationConsents.search,
-        {
-          appId: 'app1',
-          userId: 'user1',
-          consentId: 'consent1',
-          page: 1,
-        },
-        {
-          token: 'key',
-        },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.inboundApplicationConsents.search, {
+        appId: 'app1',
+        userId: 'user1',
+        consentId: 'consent1',
+        page: 1,
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -418,17 +392,11 @@ describe('Management InboundApplication', () => {
           consentIds: ['consent1'],
         });
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.inboundApplicationConsents.delete,
-        {
-          appId: 'app1',
-          userIds: ['user1'],
-          consentIds: ['consent1'],
-        },
-        {
-          token: 'key',
-        },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.inboundApplicationConsents.delete, {
+        appId: 'app1',
+        userIds: ['user1'],
+        consentIds: ['consent1'],
+      });
 
       expect(resp).toEqual({
         code: 200,

--- a/lib/management/inboundapplication.ts
+++ b/lib/management/inboundapplication.ts
@@ -1,5 +1,4 @@
-import { SdkResponse, transformResponse } from '@descope/core-js-sdk';
-import { CoreSdk } from '../types';
+import { SdkResponse, transformResponse, HttpClient } from '@descope/core-js-sdk';
 import apiPaths from './paths';
 import {
   InboundApplication,
@@ -19,89 +18,55 @@ type MultipleInboundApplicationConsentsResponse = {
   consents: InboundApplicationConsent[];
 };
 
-const withInboundApplication = (sdk: CoreSdk, managementKey?: string) => ({
+const withInboundApplication = (httpClient: HttpClient) => ({
   createApplication: (
     options: InboundApplicationOptions,
   ): Promise<SdkResponse<CreateInboundApplicationResponse>> =>
     transformResponse(
-      sdk.httpClient.post(
-        apiPaths.inboundApplication.create,
-        {
-          ...options,
-        },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.inboundApplication.create, {
+        ...options,
+      }),
     ),
   updateApplication: (
     options: InboundApplicationOptions & { id: string },
   ): Promise<SdkResponse<never>> =>
-    transformResponse(
-      sdk.httpClient.post(
-        apiPaths.inboundApplication.update,
-        { ...options },
-        { token: managementKey },
-      ),
-    ),
+    transformResponse(httpClient.post(apiPaths.inboundApplication.update, { ...options })),
   patchApplication: (
     options: Partial<InboundApplicationOptions> & { id: string },
   ): Promise<SdkResponse<never>> =>
-    transformResponse(
-      sdk.httpClient.post(
-        apiPaths.inboundApplication.patch,
-        { ...options },
-        { token: managementKey },
-      ),
-    ),
+    transformResponse(httpClient.post(apiPaths.inboundApplication.patch, { ...options })),
   deleteApplication: (id: string): Promise<SdkResponse<never>> =>
-    transformResponse(
-      sdk.httpClient.post(apiPaths.inboundApplication.delete, { id }, { token: managementKey }),
-    ),
+    transformResponse(httpClient.post(apiPaths.inboundApplication.delete, { id })),
   loadApplication: (id: string): Promise<SdkResponse<InboundApplication>> =>
     transformResponse<InboundApplication, InboundApplication>(
-      sdk.httpClient.get(apiPaths.inboundApplication.load, {
+      httpClient.get(apiPaths.inboundApplication.load, {
         queryParams: { id },
-        token: managementKey,
       }),
       (data) => data,
     ),
   loadAllApplications: (): Promise<SdkResponse<InboundApplication[]>> =>
     transformResponse<MultipleInboundApplicationResponse, InboundApplication[]>(
-      sdk.httpClient.get(apiPaths.inboundApplication.loadAll, {
-        token: managementKey,
-      }),
+      httpClient.get(apiPaths.inboundApplication.loadAll, {}),
       (data) => data.apps,
     ),
   getApplicationSecret: (id: string): Promise<SdkResponse<InboundApplicationSecretResponse>> =>
     transformResponse<InboundApplicationSecretResponse, InboundApplicationSecretResponse>(
-      sdk.httpClient.get(apiPaths.inboundApplication.secret, {
+      httpClient.get(apiPaths.inboundApplication.secret, {
         queryParams: { id },
-        token: managementKey,
       }),
       (data) => data,
     ),
   rotateApplicationSecret: (id: string): Promise<SdkResponse<never>> =>
-    transformResponse(
-      sdk.httpClient.post(apiPaths.inboundApplication.rotate, { id }, { token: managementKey }),
-    ),
+    transformResponse(httpClient.post(apiPaths.inboundApplication.rotate, { id })),
   searchConsents: (
     options?: InboundApplicationConsentSearchOptions,
   ): Promise<SdkResponse<InboundApplicationConsent[]>> =>
     transformResponse<MultipleInboundApplicationConsentsResponse, InboundApplicationConsent[]>(
-      sdk.httpClient.post(
-        apiPaths.inboundApplicationConsents.search,
-        { ...options },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.inboundApplicationConsents.search, { ...options }),
       (data) => data.consents,
     ),
   deleteConsents: (options: InboundApplicationConsentDeleteOptions): Promise<SdkResponse<never>> =>
-    transformResponse(
-      sdk.httpClient.post(
-        apiPaths.inboundApplicationConsents.delete,
-        { ...options },
-        { token: managementKey },
-      ),
-    ),
+    transformResponse(httpClient.post(apiPaths.inboundApplicationConsents.delete, { ...options })),
 });
 
 export default withInboundApplication;

--- a/lib/management/index.ts
+++ b/lib/management/index.ts
@@ -1,4 +1,3 @@
-import { CoreSdk } from '../types';
 import withUser from './user';
 import withProject from './project';
 import withTenant from './tenant';
@@ -17,27 +16,28 @@ import withPassword from './password';
 import WithFGA from './fga';
 import withInboundApplication from './inboundapplication';
 import withOutboundApplication from './outboundapplication';
+import { HttpClient } from '@descope/core-js-sdk';
 
 /** Constructs a higher level Management API that wraps the functions from code-js-sdk */
-const withManagement = (sdk: CoreSdk, managementKey?: string) => ({
-  user: withUser(sdk, managementKey),
-  project: withProject(sdk, managementKey),
-  accessKey: withAccessKey(sdk, managementKey),
-  tenant: withTenant(sdk, managementKey),
-  ssoApplication: withSSOApplication(sdk, managementKey),
-  inboundApplication: withInboundApplication(sdk, managementKey),
-  outboundApplication: withOutboundApplication(sdk, managementKey),
-  sso: withSSOSettings(sdk, managementKey),
-  jwt: withJWT(sdk, managementKey),
-  permission: withPermission(sdk, managementKey),
-  password: withPassword(sdk, managementKey),
-  role: withRole(sdk, managementKey),
-  group: withGroup(sdk, managementKey),
-  flow: WithFlow(sdk, managementKey),
-  theme: WithTheme(sdk, managementKey),
-  audit: WithAudit(sdk, managementKey),
-  authz: WithAuthz(sdk, managementKey),
-  fga: WithFGA(sdk, managementKey),
+const withManagement = (client: HttpClient) => ({
+  user: withUser(client),
+  project: withProject(client),
+  accessKey: withAccessKey(client),
+  tenant: withTenant(client),
+  ssoApplication: withSSOApplication(client),
+  inboundApplication: withInboundApplication(client),
+  outboundApplication: withOutboundApplication(client),
+  sso: withSSOSettings(client),
+  jwt: withJWT(client),
+  permission: withPermission(client),
+  password: withPassword(client),
+  role: withRole(client),
+  group: withGroup(client),
+  flow: WithFlow(client),
+  theme: WithTheme(client),
+  audit: WithAudit(client),
+  authz: WithAuthz(client),
+  fga: WithFGA(client),
 });
 
 export default withManagement;

--- a/lib/management/index.ts
+++ b/lib/management/index.ts
@@ -1,3 +1,4 @@
+import { HttpClient } from '@descope/core-js-sdk';
 import withUser from './user';
 import withProject from './project';
 import withTenant from './tenant';
@@ -16,7 +17,6 @@ import withPassword from './password';
 import WithFGA from './fga';
 import withInboundApplication from './inboundapplication';
 import withOutboundApplication from './outboundapplication';
-import { HttpClient } from '@descope/core-js-sdk';
 
 /** Constructs a higher level Management API that wraps the functions from code-js-sdk */
 const withManagement = (client: HttpClient) => ({

--- a/lib/management/jwt.test.ts
+++ b/lib/management/jwt.test.ts
@@ -2,9 +2,9 @@ import { JWTResponse, SdkResponse } from '@descope/core-js-sdk';
 import withManagement from '.';
 import apiPaths from './paths';
 import { UpdateJWTResponse } from './types';
-import { mockCoreSdk, mockHttpClient } from './testutils';
+import { mockHttpClient, resetMockHttpClient } from './testutils';
 
-const management = withManagement(mockCoreSdk, 'key');
+const management = withManagement(mockHttpClient);
 
 const mockJWTResponse = {
   jwt: 'foo',
@@ -13,7 +13,7 @@ const mockJWTResponse = {
 describe('Management JWT', () => {
   afterEach(() => {
     jest.clearAllMocks();
-    mockHttpClient.reset();
+    resetMockHttpClient();
   });
 
   describe('update', () => {
@@ -36,11 +36,11 @@ describe('Management JWT', () => {
         4,
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.jwt.update,
-        { jwt: 'jwt', customClaims: { foo: 'bar' }, refreshDuration: 4 },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.jwt.update, {
+        jwt: 'jwt',
+        customClaims: { foo: 'bar' },
+        refreshDuration: 4,
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -71,17 +71,13 @@ describe('Management JWT', () => {
         't1',
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.jwt.impersonate,
-        {
-          impersonatorId: 'imp1',
-          loginId: 'imp2',
-          validateConsent: true,
-          customClaims: { k1: 'v1' },
-          selectedTenant: 't1',
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.jwt.impersonate, {
+        impersonatorId: 'imp1',
+        loginId: 'imp2',
+        validateConsent: true,
+        customClaims: { k1: 'v1' },
+        selectedTenant: 't1',
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -111,16 +107,12 @@ describe('Management JWT', () => {
         32,
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.jwt.stopImpersonation,
-        {
-          jwt: 'jwt',
-          customClaims: { k1: 'v1' },
-          selectedTenant: 't1',
-          refreshDuration: 32,
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.jwt.stopImpersonation, {
+        jwt: 'jwt',
+        customClaims: { k1: 'v1' },
+        selectedTenant: 't1',
+        refreshDuration: 32,
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -147,11 +139,10 @@ describe('Management JWT', () => {
         customClaims: { k1: 'v1' },
       });
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.jwt.signIn,
-        { loginId: 'user-id-1', customClaims: { k1: 'v1' } },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.jwt.signIn, {
+        loginId: 'user-id-1',
+        customClaims: { k1: 'v1' },
+      });
 
       expect(resp).toEqual({ code: 200, data: mockJWTResponse, ok: true, response: httpResponse });
     });
@@ -180,18 +171,14 @@ describe('Management JWT', () => {
         },
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.jwt.signUp,
-        {
-          loginId: 'user-id-1',
-          user: {
-            email: 'test@example.com',
-            name: 'lorem ipsum',
-          },
-          customClaims: { k1: 'v1' },
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.jwt.signUp, {
+        loginId: 'user-id-1',
+        user: {
+          email: 'test@example.com',
+          name: 'lorem ipsum',
         },
-        { token: 'key' },
-      );
+        customClaims: { k1: 'v1' },
+      });
 
       expect(resp).toEqual({ code: 200, data: mockJWTResponse, ok: true, response: httpResponse });
     });
@@ -220,18 +207,14 @@ describe('Management JWT', () => {
         },
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.jwt.signUpOrIn,
-        {
-          loginId: 'user-id-1',
-          user: {
-            email: 'test@example.com',
-            name: 'lorem ipsum',
-          },
-          customClaims: { k1: 'v1' },
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.jwt.signUpOrIn, {
+        loginId: 'user-id-1',
+        user: {
+          email: 'test@example.com',
+          name: 'lorem ipsum',
         },
-        { token: 'key' },
-      );
+        customClaims: { k1: 'v1' },
+      });
 
       expect(resp).toEqual({ code: 200, data: mockJWTResponse, ok: true, response: httpResponse });
     });
@@ -251,11 +234,10 @@ describe('Management JWT', () => {
 
       const resp: SdkResponse<JWTResponse> = await management.jwt.anonymous({ k1: 'v1' }, 't1');
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.jwt.anonymous,
-        { customClaims: { k1: 'v1' }, selectedTenant: 't1' },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.jwt.anonymous, {
+        customClaims: { k1: 'v1' },
+        selectedTenant: 't1',
+      });
 
       expect(resp).toEqual({ code: 200, data: mockJWTResponse, ok: true, response: httpResponse });
     });

--- a/lib/management/jwt.ts
+++ b/lib/management/jwt.ts
@@ -1,23 +1,16 @@
-import { JWTResponse, SdkResponse, transformResponse } from '@descope/core-js-sdk';
-import { CoreSdk } from '../types';
+import { JWTResponse, SdkResponse, transformResponse, HttpClient } from '@descope/core-js-sdk';
 import apiPaths from './paths';
 import { MgmtLoginOptions, MgmtSignUpOptions, MgmtUserOptions, UpdateJWTResponse } from './types';
 
 type AnonymousJWTResponse = Omit<JWTResponse, 'user' | 'firstSeen'>;
 
-const withJWT = (sdk: CoreSdk, managementKey?: string) => ({
+const withJWT = (httpClient: HttpClient) => ({
   update: (
     jwt: string,
     customClaims?: Record<string, any>,
     refreshDuration?: number,
   ): Promise<SdkResponse<UpdateJWTResponse>> =>
-    transformResponse(
-      sdk.httpClient.post(
-        apiPaths.jwt.update,
-        { jwt, customClaims, refreshDuration },
-        { token: managementKey },
-      ),
-    ),
+    transformResponse(httpClient.post(apiPaths.jwt.update, { jwt, customClaims, refreshDuration })),
   impersonate: (
     impersonatorId: string,
     loginId: string,
@@ -27,11 +20,14 @@ const withJWT = (sdk: CoreSdk, managementKey?: string) => ({
     refreshDuration?: number,
   ): Promise<SdkResponse<UpdateJWTResponse>> =>
     transformResponse(
-      sdk.httpClient.post(
-        apiPaths.jwt.impersonate,
-        { impersonatorId, loginId, validateConsent, customClaims, selectedTenant, refreshDuration },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.jwt.impersonate, {
+        impersonatorId,
+        loginId,
+        validateConsent,
+        customClaims,
+        selectedTenant,
+        refreshDuration,
+      }),
     ),
   stopImpersonation: (
     jwt: string,
@@ -40,43 +36,28 @@ const withJWT = (sdk: CoreSdk, managementKey?: string) => ({
     refreshDuration?: number,
   ): Promise<SdkResponse<UpdateJWTResponse>> =>
     transformResponse(
-      sdk.httpClient.post(
-        apiPaths.jwt.stopImpersonation,
-        { jwt, customClaims, selectedTenant, refreshDuration },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.jwt.stopImpersonation, {
+        jwt,
+        customClaims,
+        selectedTenant,
+        refreshDuration,
+      }),
     ),
   signIn: (loginId: string, loginOptions?: MgmtLoginOptions): Promise<SdkResponse<JWTResponse>> =>
-    transformResponse(
-      sdk.httpClient.post(
-        apiPaths.jwt.signIn,
-        { loginId, ...loginOptions },
-        { token: managementKey },
-      ),
-    ),
+    transformResponse(httpClient.post(apiPaths.jwt.signIn, { loginId, ...loginOptions })),
   signUp: (
     loginId: string,
     user?: MgmtUserOptions,
     signUpOptions?: MgmtSignUpOptions,
   ): Promise<SdkResponse<JWTResponse>> =>
-    transformResponse(
-      sdk.httpClient.post(
-        apiPaths.jwt.signUp,
-        { loginId, user, ...signUpOptions },
-        { token: managementKey },
-      ),
-    ),
+    transformResponse(httpClient.post(apiPaths.jwt.signUp, { loginId, user, ...signUpOptions })),
   signUpOrIn: (
     loginId: string,
     user?: MgmtUserOptions,
     signUpOptions?: MgmtSignUpOptions,
   ): Promise<SdkResponse<JWTResponse>> =>
     transformResponse(
-      sdk.httpClient.post(
-        apiPaths.jwt.signUpOrIn,
-        { loginId, user, ...signUpOptions },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.jwt.signUpOrIn, { loginId, user, ...signUpOptions }),
     ),
   anonymous: (
     customClaims?: Record<string, any>,
@@ -84,11 +65,7 @@ const withJWT = (sdk: CoreSdk, managementKey?: string) => ({
     refreshDuration?: number,
   ): Promise<SdkResponse<AnonymousJWTResponse>> =>
     transformResponse(
-      sdk.httpClient.post(
-        apiPaths.jwt.anonymous,
-        { customClaims, selectedTenant, refreshDuration },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.jwt.anonymous, { customClaims, selectedTenant, refreshDuration }),
     ),
 });
 

--- a/lib/management/outboundapplication.test.ts
+++ b/lib/management/outboundapplication.test.ts
@@ -2,9 +2,9 @@ import { SdkResponse } from '@descope/core-js-sdk';
 import withManagement from '.';
 import apiPaths from './paths';
 import { OutboundApplication, OutboundAppToken } from './types';
-import { mockCoreSdk, mockHttpClient } from './testutils';
+import { mockHttpClient, resetMockHttpClient } from './testutils';
 
-const management = withManagement(mockCoreSdk, 'key');
+const management = withManagement(mockHttpClient);
 
 const mockOutboundApplicationResponse = {
   app: {
@@ -52,7 +52,7 @@ const mockFetchTokenResponse = {
 describe('Management OutboundApplication', () => {
   afterEach(() => {
     jest.clearAllMocks();
-    mockHttpClient.reset();
+    resetMockHttpClient();
   });
 
   describe('createOutboundApplication', () => {
@@ -74,15 +74,11 @@ describe('Management OutboundApplication', () => {
           clientSecret: 'shhh..',
         });
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.outboundApplication.create,
-        {
-          name: 'name',
-          description: 'test',
-          clientSecret: 'shhh..',
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.outboundApplication.create, {
+        name: 'name',
+        description: 'test',
+        clientSecret: 'shhh..',
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -113,19 +109,15 @@ describe('Management OutboundApplication', () => {
         clientSecret: 'shhh..',
       });
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.outboundApplication.update,
-        {
-          app: {
-            id: 'app1',
-            name: 'name',
-            logo: 'logo',
-            description: 'desc',
-            clientSecret: 'shhh..',
-          },
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.outboundApplication.update, {
+        app: {
+          id: 'app1',
+          name: 'name',
+          logo: 'logo',
+          description: 'desc',
+          clientSecret: 'shhh..',
         },
-        { token: 'key' },
-      );
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -150,11 +142,9 @@ describe('Management OutboundApplication', () => {
 
       const resp = await management.outboundApplication.deleteApplication('app1');
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.outboundApplication.delete,
-        { id: 'app1' },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.outboundApplication.delete, {
+        id: 'app1',
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -184,9 +174,6 @@ describe('Management OutboundApplication', () => {
 
       expect(mockHttpClient.get).toHaveBeenCalledWith(
         `${apiPaths.outboundApplication.load}/${mockOutboundApplicationResponse.app.id}`,
-        {
-          token: 'key',
-        },
       );
 
       expect(resp).toEqual({
@@ -213,9 +200,7 @@ describe('Management OutboundApplication', () => {
       const resp: SdkResponse<OutboundApplication[]> =
         await management.outboundApplication.loadAllApplications();
 
-      expect(mockHttpClient.get).toHaveBeenCalledWith(apiPaths.outboundApplication.loadAll, {
-        token: 'key',
-      });
+      expect(mockHttpClient.get).toHaveBeenCalledWith(apiPaths.outboundApplication.loadAll, {});
 
       expect(resp).toEqual({
         code: 200,
@@ -256,7 +241,6 @@ describe('Management OutboundApplication', () => {
           options: { withRefreshToken: true, forceRefresh: true },
           tenantId: 'tenant789',
         },
-        { token: 'key' },
       );
 
       expect(resp).toEqual({
@@ -290,7 +274,6 @@ describe('Management OutboundApplication', () => {
           options: undefined,
           tenantId: undefined,
         },
-        { token: 'key' },
       );
 
       expect(resp).toEqual({
@@ -321,16 +304,12 @@ describe('Management OutboundApplication', () => {
         { forceRefresh: true },
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.outboundApplication.fetchToken,
-        {
-          appId: 'app123',
-          userId: 'user456',
-          tenantId: 'tenant789',
-          options: { forceRefresh: true },
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.outboundApplication.fetchToken, {
+        appId: 'app123',
+        userId: 'user456',
+        tenantId: 'tenant789',
+        options: { forceRefresh: true },
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -356,16 +335,12 @@ describe('Management OutboundApplication', () => {
         'user456',
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.outboundApplication.fetchToken,
-        {
-          appId: 'app123',
-          userId: 'user456',
-          tenantId: undefined,
-          options: undefined,
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.outboundApplication.fetchToken, {
+        appId: 'app123',
+        userId: 'user456',
+        tenantId: undefined,
+        options: undefined,
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -404,7 +379,6 @@ describe('Management OutboundApplication', () => {
           scopes: ['read', 'write'],
           options: { withRefreshToken: true, forceRefresh: true },
         },
-        { token: 'key' },
       );
 
       expect(resp).toEqual({
@@ -439,7 +413,6 @@ describe('Management OutboundApplication', () => {
           scopes: ['read'],
           options: undefined,
         },
-        { token: 'key' },
       );
 
       expect(resp).toEqual({
@@ -475,7 +448,6 @@ describe('Management OutboundApplication', () => {
           tenantId: 'tenant789',
           options: { forceRefresh: true },
         },
-        { token: 'key' },
       );
 
       expect(resp).toEqual({
@@ -507,7 +479,6 @@ describe('Management OutboundApplication', () => {
           tenantId: 'tenant789',
           options: undefined,
         },
-        { token: 'key' },
       );
 
       expect(resp).toEqual({

--- a/lib/management/outboundapplication.ts
+++ b/lib/management/outboundapplication.ts
@@ -17,7 +17,7 @@ type MultipleOutboundApplicationResponse = {
 
 type WithOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 
-const withOutboundApplication = (httpClient: HttpClient, managementKey?: string) => ({
+const withOutboundApplication = (httpClient: HttpClient) => ({
   createApplication: (
     app: WithOptional<OutboundApplication, 'id'> & { clientSecret?: string },
   ): Promise<SdkResponse<OutboundApplication>> =>

--- a/lib/management/outboundapplication.ts
+++ b/lib/management/outboundapplication.ts
@@ -1,5 +1,4 @@
-import { SdkResponse, transformResponse } from '@descope/core-js-sdk';
-import { CoreSdk } from '../types';
+import { SdkResponse, transformResponse, HttpClient } from '@descope/core-js-sdk';
 import apiPaths from './paths';
 import {
   OutboundApplication,
@@ -18,49 +17,35 @@ type MultipleOutboundApplicationResponse = {
 
 type WithOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 
-const withOutboundApplication = (sdk: CoreSdk, managementKey?: string) => ({
+const withOutboundApplication = (httpClient: HttpClient, managementKey?: string) => ({
   createApplication: (
     app: WithOptional<OutboundApplication, 'id'> & { clientSecret?: string },
   ): Promise<SdkResponse<OutboundApplication>> =>
     transformResponse<OutboundApplicationResponse, OutboundApplication>(
-      sdk.httpClient.post(
-        apiPaths.outboundApplication.create,
-        {
-          ...app,
-        },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.outboundApplication.create, {
+        ...app,
+      }),
       (data) => data.app,
     ),
   updateApplication: (
     app: OutboundApplication & { clientSecret?: string },
   ): Promise<SdkResponse<OutboundApplication>> =>
     transformResponse<OutboundApplicationResponse, OutboundApplication>(
-      sdk.httpClient.post(
-        apiPaths.outboundApplication.update,
-        {
-          app,
-        },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.outboundApplication.update, {
+        app,
+      }),
       (data) => data.app,
     ),
   deleteApplication: (id: string): Promise<SdkResponse<never>> =>
-    transformResponse(
-      sdk.httpClient.post(apiPaths.outboundApplication.delete, { id }, { token: managementKey }),
-    ),
+    transformResponse(httpClient.post(apiPaths.outboundApplication.delete, { id })),
   loadApplication: (id: string): Promise<SdkResponse<OutboundApplication>> =>
     transformResponse<OutboundApplicationResponse, OutboundApplication>(
-      sdk.httpClient.get(`${apiPaths.outboundApplication.load}/${id}`, {
-        token: managementKey,
-      }),
+      httpClient.get(`${apiPaths.outboundApplication.load}/${id}`),
       (data) => data.app,
     ),
   loadAllApplications: (): Promise<SdkResponse<OutboundApplication[]>> =>
     transformResponse<MultipleOutboundApplicationResponse, OutboundApplication[]>(
-      sdk.httpClient.get(apiPaths.outboundApplication.loadAll, {
-        token: managementKey,
-      }),
+      httpClient.get(apiPaths.outboundApplication.loadAll, {}),
       (data) => data.apps,
     ),
   fetchTokenByScopes: (
@@ -71,17 +56,13 @@ const withOutboundApplication = (sdk: CoreSdk, managementKey?: string) => ({
     tenantId?: string,
   ): Promise<SdkResponse<OutboundAppToken>> =>
     transformResponse<OutboundAppTokenResponse, OutboundAppToken>(
-      sdk.httpClient.post(
-        apiPaths.outboundApplication.fetchTokenByScopes,
-        {
-          appId,
-          userId,
-          scopes,
-          options,
-          tenantId,
-        },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.outboundApplication.fetchTokenByScopes, {
+        appId,
+        userId,
+        scopes,
+        options,
+        tenantId,
+      }),
       (data) => data.token,
     ),
   fetchToken: (
@@ -91,16 +72,12 @@ const withOutboundApplication = (sdk: CoreSdk, managementKey?: string) => ({
     options?: FetchOutboundAppTokenOptions,
   ): Promise<SdkResponse<OutboundAppToken>> =>
     transformResponse<OutboundAppTokenResponse, OutboundAppToken>(
-      sdk.httpClient.post(
-        apiPaths.outboundApplication.fetchToken,
-        {
-          appId,
-          userId,
-          tenantId,
-          options,
-        },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.outboundApplication.fetchToken, {
+        appId,
+        userId,
+        tenantId,
+        options,
+      }),
       (data) => data.token,
     ),
   fetchTenantTokenByScopes: (
@@ -110,16 +87,12 @@ const withOutboundApplication = (sdk: CoreSdk, managementKey?: string) => ({
     options?: FetchOutboundAppTokenOptions,
   ): Promise<SdkResponse<OutboundAppToken>> =>
     transformResponse<OutboundAppTokenResponse, OutboundAppToken>(
-      sdk.httpClient.post(
-        apiPaths.outboundApplication.fetchTenantTokenByScopes,
-        {
-          appId,
-          tenantId,
-          scopes,
-          options,
-        },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.outboundApplication.fetchTenantTokenByScopes, {
+        appId,
+        tenantId,
+        scopes,
+        options,
+      }),
       (data) => data.token,
     ),
   fetchTenantToken: (
@@ -128,15 +101,11 @@ const withOutboundApplication = (sdk: CoreSdk, managementKey?: string) => ({
     options?: FetchOutboundAppTokenOptions,
   ): Promise<SdkResponse<OutboundAppToken>> =>
     transformResponse<OutboundAppTokenResponse, OutboundAppToken>(
-      sdk.httpClient.post(
-        apiPaths.outboundApplication.fetchTenantToken,
-        {
-          appId,
-          tenantId,
-          options,
-        },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.outboundApplication.fetchTenantToken, {
+        appId,
+        tenantId,
+        options,
+      }),
       (data) => data.token,
     ),
 });

--- a/lib/management/password.test.ts
+++ b/lib/management/password.test.ts
@@ -2,9 +2,9 @@ import { SdkResponse } from '@descope/core-js-sdk';
 import withManagement from '.';
 import apiPaths from './paths';
 import { PasswordSettings } from './types';
-import { mockCoreSdk, mockHttpClient } from './testutils';
+import { mockHttpClient, resetMockHttpClient } from './testutils';
 
-const management = withManagement(mockCoreSdk, 'key');
+const management = withManagement(mockHttpClient);
 
 const mockPasswordSettings: PasswordSettings = {
   enabled: true,
@@ -24,7 +24,7 @@ const mockPasswordSettings: PasswordSettings = {
 describe('Management Password', () => {
   afterEach(() => {
     jest.clearAllMocks();
-    mockHttpClient.reset();
+    resetMockHttpClient();
   });
 
   describe('getSettings', () => {
@@ -43,7 +43,6 @@ describe('Management Password', () => {
 
       expect(mockHttpClient.get).toHaveBeenCalledWith(apiPaths.password.settings, {
         queryParams: { tenantId: 'test' },
-        token: 'key',
       });
 
       expect(resp).toEqual({
@@ -72,13 +71,10 @@ describe('Management Password', () => {
         mockPasswordSettings,
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.password.settings,
-        { ...mockPasswordSettings, tenantId: 'test' },
-        {
-          token: 'key',
-        },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.password.settings, {
+        ...mockPasswordSettings,
+        tenantId: 'test',
+      });
 
       expect(resp).toEqual({
         code: 200,

--- a/lib/management/password.ts
+++ b/lib/management/password.ts
@@ -1,27 +1,17 @@
-import { SdkResponse, transformResponse } from '@descope/core-js-sdk';
-import { CoreSdk } from '../types';
+import { SdkResponse, transformResponse, HttpClient } from '@descope/core-js-sdk';
 import apiPaths from './paths';
 import { PasswordSettings } from './types';
 
-const withPassword = (sdk: CoreSdk, managementKey?: string) => ({
+const withPassword = (httpClient: HttpClient) => ({
   getSettings: (tenantId: string): Promise<SdkResponse<PasswordSettings>> =>
     transformResponse<PasswordSettings, PasswordSettings>(
-      sdk.httpClient.get(apiPaths.password.settings, {
+      httpClient.get(apiPaths.password.settings, {
         queryParams: { tenantId },
-        token: managementKey,
       }),
       (data) => data,
     ),
   configureSettings: (tenantId: string, settings: PasswordSettings): Promise<SdkResponse<never>> =>
-    transformResponse(
-      sdk.httpClient.post(
-        apiPaths.password.settings,
-        { ...settings, tenantId },
-        {
-          token: managementKey,
-        },
-      ),
-    ),
+    transformResponse(httpClient.post(apiPaths.password.settings, { ...settings, tenantId })),
 });
 
 export default withPassword;

--- a/lib/management/permission.test.ts
+++ b/lib/management/permission.test.ts
@@ -1,10 +1,10 @@
 import { SdkResponse } from '@descope/core-js-sdk';
 import withManagement from '.';
 import apiPaths from './paths';
-import { mockCoreSdk, mockHttpClient } from './testutils';
+import { mockHttpClient, resetMockHttpClient } from './testutils';
 import { Permission } from './types';
 
-const management = withManagement(mockCoreSdk, 'key');
+const management = withManagement(mockHttpClient);
 
 const mockPermissions = [
   { name: 'name', description: 'description', systemDefault: true },
@@ -19,7 +19,7 @@ const mockAllPermissionsResponse = {
 describe('Management Permission', () => {
   afterEach(() => {
     jest.clearAllMocks();
-    mockHttpClient.reset();
+    resetMockHttpClient();
   });
 
   describe('create', () => {
@@ -35,11 +35,10 @@ describe('Management Permission', () => {
 
       const resp = await management.permission.create('name', 'description');
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.permission.create,
-        { name: 'name', description: 'description' },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.permission.create, {
+        name: 'name',
+        description: 'description',
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -62,11 +61,11 @@ describe('Management Permission', () => {
 
       const resp = await management.permission.update('name', 'newName', 'description');
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.permission.update,
-        { name: 'name', newName: 'newName', description: 'description' },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.permission.update, {
+        name: 'name',
+        newName: 'newName',
+        description: 'description',
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -89,11 +88,9 @@ describe('Management Permission', () => {
 
       const resp = await management.permission.delete('name');
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.permission.delete,
-        { name: 'name' },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.permission.delete, {
+        name: 'name',
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -117,9 +114,7 @@ describe('Management Permission', () => {
 
       const resp: SdkResponse<Permission[]> = await management.permission.loadAll();
 
-      expect(mockHttpClient.get).toHaveBeenCalledWith(apiPaths.permission.loadAll, {
-        token: 'key',
-      });
+      expect(mockHttpClient.get).toHaveBeenCalledWith(apiPaths.permission.loadAll, {});
 
       expect(resp).toEqual({
         code: 200,

--- a/lib/management/permission.ts
+++ b/lib/management/permission.ts
@@ -1,5 +1,4 @@
-import { SdkResponse, transformResponse } from '@descope/core-js-sdk';
-import { CoreSdk } from '../types';
+import { SdkResponse, transformResponse, HttpClient } from '@descope/core-js-sdk';
 import apiPaths from './paths';
 import { Permission } from './types';
 
@@ -7,32 +6,16 @@ type MultiplePermissionResponse = {
   permissions: Permission[];
 };
 
-const withPermission = (sdk: CoreSdk, managementKey?: string) => ({
+const withPermission = (httpClient: HttpClient) => ({
   create: (name: string, description?: string): Promise<SdkResponse<never>> =>
-    transformResponse(
-      sdk.httpClient.post(
-        apiPaths.permission.create,
-        { name, description },
-        { token: managementKey },
-      ),
-    ),
+    transformResponse(httpClient.post(apiPaths.permission.create, { name, description })),
   update: (name: string, newName: string, description?: string): Promise<SdkResponse<never>> =>
-    transformResponse(
-      sdk.httpClient.post(
-        apiPaths.permission.update,
-        { name, newName, description },
-        { token: managementKey },
-      ),
-    ),
+    transformResponse(httpClient.post(apiPaths.permission.update, { name, newName, description })),
   delete: (name: string): Promise<SdkResponse<never>> =>
-    transformResponse(
-      sdk.httpClient.post(apiPaths.permission.delete, { name }, { token: managementKey }),
-    ),
+    transformResponse(httpClient.post(apiPaths.permission.delete, { name })),
   loadAll: (): Promise<SdkResponse<Permission[]>> =>
     transformResponse<MultiplePermissionResponse, Permission[]>(
-      sdk.httpClient.get(apiPaths.permission.loadAll, {
-        token: managementKey,
-      }),
+      httpClient.get(apiPaths.permission.loadAll, {}),
       (data) => data.permissions,
     ),
 });

--- a/lib/management/project.test.ts
+++ b/lib/management/project.test.ts
@@ -1,7 +1,7 @@
 import { SdkResponse } from '@descope/core-js-sdk';
 import withManagement from '.';
 import apiPaths from './paths';
-import { mockCoreSdk, mockHttpClient } from './testutils';
+import { mockHttpClient, resetMockHttpClient } from './testutils';
 import {
   ExportSnapshotResponse,
   ImportSnapshotRequest,
@@ -10,7 +10,7 @@ import {
   ValidateSnapshotResponse,
 } from './types';
 
-const management = withManagement(mockCoreSdk, 'key');
+const management = withManagement(mockHttpClient);
 
 const mockMgmtListProjectsResponse = {
   projects: [
@@ -36,7 +36,7 @@ const mockListProjectsResponse: Project[] = [
 describe('Management Project', () => {
   afterEach(() => {
     jest.clearAllMocks();
-    mockHttpClient.reset();
+    resetMockHttpClient();
   });
 
   describe('updateName', () => {
@@ -54,11 +54,7 @@ describe('Management Project', () => {
       const name = 'new project name';
       const resp = await management.project.updateName(name);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.project.updateName,
-        { name },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.project.updateName, { name });
 
       expect(resp).toEqual({
         code: 200,
@@ -84,11 +80,7 @@ describe('Management Project', () => {
       const tags = ['tag1!', 'tag2'];
       const resp = await management.project.updateTags(tags);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.project.updateTags,
-        { tags },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.project.updateTags, { tags });
 
       expect(resp).toEqual({
         code: 200,
@@ -113,13 +105,7 @@ describe('Management Project', () => {
 
       const resp: SdkResponse<Project[]> = await management.project.listProjects();
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.project.projectsList,
-        {},
-        {
-          token: 'key',
-        },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.project.projectsList, {});
       expect(resp).toEqual({
         code: 200,
         data: mockListProjectsResponse,
@@ -150,11 +136,11 @@ describe('Management Project', () => {
       const environment = 'production';
       const tags = ['tag1', 'tag2@'];
       const resp = await management.project.clone('name1', environment, tags);
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.project.clone,
-        { name, environment, tags },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.project.clone, {
+        name,
+        environment,
+        tags,
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -187,11 +173,7 @@ describe('Management Project', () => {
 
       const resp = await management.project.exportSnapshot();
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.project.exportSnapshot,
-        {},
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.project.exportSnapshot, {});
 
       expect(resp).toEqual({
         code: 200,
@@ -229,7 +211,6 @@ describe('Management Project', () => {
       expect(mockHttpClient.post).toHaveBeenCalledWith(
         apiPaths.project.importSnapshot,
         importSnapshotRequest,
-        { token: 'key' },
       );
 
       expect(resp).toEqual({
@@ -274,7 +255,6 @@ describe('Management Project', () => {
       expect(mockHttpClient.post).toHaveBeenCalledWith(
         apiPaths.project.validateSnapshot,
         validateSnapshotRequest,
-        { token: 'key' },
       );
 
       expect(resp).toEqual({
@@ -308,11 +288,7 @@ describe('Management Project', () => {
 
       const resp = await management.project.export();
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.project.exportSnapshot,
-        {},
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.project.exportSnapshot, {});
 
       expect(resp).toEqual({
         code: 200,
@@ -339,17 +315,13 @@ describe('Management Project', () => {
 
       const resp = await management.project.import({ 'foo/bar.json': { foo: 'bar' } });
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.project.importSnapshot,
-        {
-          files: {
-            'foo/bar.json': {
-              foo: 'bar',
-            },
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.project.importSnapshot, {
+        files: {
+          'foo/bar.json': {
+            foo: 'bar',
           },
         },
-        { token: 'key' },
-      );
+      });
 
       expect(resp).toEqual({
         code: 200,

--- a/lib/management/project.ts
+++ b/lib/management/project.ts
@@ -1,5 +1,4 @@
-import { SdkResponse, transformResponse } from '@descope/core-js-sdk';
-import { CoreSdk } from '../types';
+import { SdkResponse, transformResponse, HttpClient } from '@descope/core-js-sdk';
 import apiPaths from './paths';
 import {
   CloneProjectResponse,
@@ -15,20 +14,16 @@ type ListProjectsResponse = {
   projects: Project[];
 };
 
-const withProject = (sdk: CoreSdk, managementKey?: string) => ({
+const withProject = (httpClient: HttpClient) => ({
   /**
    * Update the current project name.
    * @param name The new name of the project
    */
   updateName: (name: string): Promise<SdkResponse<never>> =>
     transformResponse(
-      sdk.httpClient.post(
-        apiPaths.project.updateName,
-        {
-          name,
-        },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.project.updateName, {
+        name,
+      }),
     ),
 
   /**
@@ -37,13 +32,9 @@ const withProject = (sdk: CoreSdk, managementKey?: string) => ({
    */
   updateTags: (tags: string[]): Promise<SdkResponse<never>> =>
     transformResponse(
-      sdk.httpClient.post(
-        apiPaths.project.updateTags,
-        {
-          tags,
-        },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.project.updateTags, {
+        tags,
+      }),
     ),
   /**
    * Clone the current project, including its settings and configurations.
@@ -60,15 +51,11 @@ const withProject = (sdk: CoreSdk, managementKey?: string) => ({
     tags?: string[],
   ): Promise<SdkResponse<CloneProjectResponse>> =>
     transformResponse(
-      sdk.httpClient.post(
-        apiPaths.project.clone,
-        {
-          name,
-          environment,
-          tags,
-        },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.project.clone, {
+        name,
+        environment,
+        tags,
+      }),
     ),
 
   /**
@@ -77,13 +64,7 @@ const withProject = (sdk: CoreSdk, managementKey?: string) => ({
    */
   listProjects: async (): Promise<SdkResponse<Project[]>> =>
     transformResponse<ListProjectsResponse, Project[]>(
-      sdk.httpClient.post(
-        apiPaths.project.projectsList,
-        {},
-        {
-          token: managementKey,
-        },
-      ),
+      httpClient.post(apiPaths.project.projectsList, {}),
       (data) =>
         data.projects.map(({ id, name, environment, tags }) => ({
           id,
@@ -111,9 +92,7 @@ const withProject = (sdk: CoreSdk, managementKey?: string) => ({
    * @returns An `ExportSnapshotResponse` object containing the exported JSON files.
    */
   exportSnapshot: (): Promise<SdkResponse<ExportSnapshotResponse>> =>
-    transformResponse(
-      sdk.httpClient.post(apiPaths.project.exportSnapshot, {}, { token: managementKey }),
-    ),
+    transformResponse(httpClient.post(apiPaths.project.exportSnapshot, {})),
 
   /**
    * Imports a snapshot of all settings and configurations into a project, overriding any
@@ -137,9 +116,7 @@ const withProject = (sdk: CoreSdk, managementKey?: string) => ({
    * found at https://github.com/descope/descopecli
    */
   importSnapshot: (request: ImportSnapshotRequest): Promise<SdkResponse<never>> =>
-    transformResponse(
-      sdk.httpClient.post(apiPaths.project.importSnapshot, request, { token: managementKey }),
-    ),
+    transformResponse(httpClient.post(apiPaths.project.importSnapshot, request)),
 
   /**
    * Validates a snapshot by performing an import dry run and reporting any validation
@@ -163,31 +140,22 @@ const withProject = (sdk: CoreSdk, managementKey?: string) => ({
   validateSnapshot: (
     request: ValidateSnapshotRequest,
   ): Promise<SdkResponse<ValidateSnapshotResponse>> =>
-    transformResponse(
-      sdk.httpClient.post(apiPaths.project.validateSnapshot, request, { token: managementKey }),
-    ),
+    transformResponse(httpClient.post(apiPaths.project.validateSnapshot, request)),
 
   /**
    * @deprecated Use exportSnapshot instead
    */
   export: (): Promise<SdkResponse<Record<string, any>>> =>
-    transformResponse(
-      sdk.httpClient.post(apiPaths.project.exportSnapshot, {}, { token: managementKey }),
-      (data) => data.files,
-    ),
+    transformResponse(httpClient.post(apiPaths.project.exportSnapshot, {}), (data) => data.files),
 
   /**
    * @deprecated Use importSnapshot instead
    */
   import: (files: Record<string, any>): Promise<SdkResponse<never>> =>
     transformResponse(
-      sdk.httpClient.post(
-        apiPaths.project.importSnapshot,
-        {
-          files,
-        },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.project.importSnapshot, {
+        files,
+      }),
     ),
 });
 

--- a/lib/management/role.test.ts
+++ b/lib/management/role.test.ts
@@ -1,10 +1,10 @@
 import { SdkResponse } from '@descope/core-js-sdk';
 import withManagement from '.';
 import apiPaths from './paths';
-import { mockCoreSdk, mockHttpClient } from './testutils';
+import { mockHttpClient, resetMockHttpClient } from './testutils';
 import { Role, RoleSearchOptions } from './types';
 
-const management = withManagement(mockCoreSdk, 'key');
+const management = withManagement(mockHttpClient);
 
 const mockRoles = [
   {
@@ -35,7 +35,7 @@ const mockAllRolesResponse = {
 describe('Management Role', () => {
   afterEach(() => {
     jest.clearAllMocks();
-    mockHttpClient.reset();
+    resetMockHttpClient();
   });
 
   describe('create', () => {
@@ -51,17 +51,13 @@ describe('Management Role', () => {
 
       const resp = await management.role.create('name', 'description', ['p1', 'p2'], 't1', true);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.role.create,
-        {
-          name: 'name',
-          description: 'description',
-          permissionNames: ['p1', 'p2'],
-          tenantId: 't1',
-          default: true,
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.role.create, {
+        name: 'name',
+        description: 'description',
+        permissionNames: ['p1', 'p2'],
+        tenantId: 't1',
+        default: true,
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -91,18 +87,14 @@ describe('Management Role', () => {
         true,
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.role.update,
-        {
-          name: 'name',
-          tenantId: 't1',
-          newName: 'newName',
-          description: 'description',
-          permissionNames: ['p1', 'p2'],
-          default: true,
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.role.update, {
+        name: 'name',
+        tenantId: 't1',
+        newName: 'newName',
+        description: 'description',
+        permissionNames: ['p1', 'p2'],
+        default: true,
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -125,11 +117,10 @@ describe('Management Role', () => {
 
       const resp = await management.role.delete('name', 't1');
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.role.delete,
-        { name: 'name', tenantId: 't1' },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.role.delete, {
+        name: 'name',
+        tenantId: 't1',
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -153,9 +144,7 @@ describe('Management Role', () => {
 
       const resp: SdkResponse<Role[]> = await management.role.loadAll();
 
-      expect(mockHttpClient.get).toHaveBeenCalledWith(apiPaths.role.loadAll, {
-        token: 'key',
-      });
+      expect(mockHttpClient.get).toHaveBeenCalledWith(apiPaths.role.loadAll, {});
 
       expect(resp).toEqual({
         code: 200,
@@ -185,9 +174,7 @@ describe('Management Role', () => {
       };
       const resp: SdkResponse<Role[]> = await management.role.search(req);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.role.search, req, {
-        token: 'key',
-      });
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.role.search, req, {});
 
       expect(resp).toEqual({
         code: 200,

--- a/lib/management/role.ts
+++ b/lib/management/role.ts
@@ -1,5 +1,4 @@
-import { SdkResponse, transformResponse } from '@descope/core-js-sdk';
-import { CoreSdk } from '../types';
+import { SdkResponse, transformResponse, HttpClient } from '@descope/core-js-sdk';
 import apiPaths from './paths';
 import { Role, RoleSearchOptions } from './types';
 
@@ -7,7 +6,7 @@ type MultipleRoleResponse = {
   roles: Role[];
 };
 
-const withRole = (sdk: CoreSdk, managementKey?: string) => ({
+const withRole = (httpClient: HttpClient) => ({
   create: (
     name: string,
     description?: string,
@@ -16,11 +15,13 @@ const withRole = (sdk: CoreSdk, managementKey?: string) => ({
     defaultRole?: boolean,
   ): Promise<SdkResponse<never>> =>
     transformResponse(
-      sdk.httpClient.post(
-        apiPaths.role.create,
-        { name, description, permissionNames, tenantId, default: defaultRole },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.role.create, {
+        name,
+        description,
+        permissionNames,
+        tenantId,
+        default: defaultRole,
+      }),
     ),
   update: (
     name: string,
@@ -31,28 +32,25 @@ const withRole = (sdk: CoreSdk, managementKey?: string) => ({
     defaultRole?: boolean,
   ): Promise<SdkResponse<never>> =>
     transformResponse(
-      sdk.httpClient.post(
-        apiPaths.role.update,
-        { name, newName, description, permissionNames, tenantId, default: defaultRole },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.role.update, {
+        name,
+        newName,
+        description,
+        permissionNames,
+        tenantId,
+        default: defaultRole,
+      }),
     ),
   delete: (name: string, tenantId?: string): Promise<SdkResponse<never>> =>
-    transformResponse(
-      sdk.httpClient.post(apiPaths.role.delete, { name, tenantId }, { token: managementKey }),
-    ),
+    transformResponse(httpClient.post(apiPaths.role.delete, { name, tenantId })),
   loadAll: (): Promise<SdkResponse<Role[]>> =>
     transformResponse<MultipleRoleResponse, Role[]>(
-      sdk.httpClient.get(apiPaths.role.loadAll, {
-        token: managementKey,
-      }),
+      httpClient.get(apiPaths.role.loadAll, {}),
       (data) => data.roles,
     ),
   search: (options: RoleSearchOptions): Promise<SdkResponse<Role[]>> =>
     transformResponse<MultipleRoleResponse, Role[]>(
-      sdk.httpClient.post(apiPaths.role.search, options, {
-        token: managementKey,
-      }),
+      httpClient.post(apiPaths.role.search, options, {}),
       (data) => data.roles,
     ),
 });

--- a/lib/management/sso.test.ts
+++ b/lib/management/sso.test.ts
@@ -1,13 +1,13 @@
 import withManagement from '.';
 import apiPaths from './paths';
-import { mockCoreSdk, mockHttpClient } from './testutils';
+import { mockHttpClient, resetMockHttpClient } from './testutils';
 
-const management = withManagement(mockCoreSdk, 'key');
+const management = withManagement(mockHttpClient);
 
 describe('Management SSO', () => {
   afterEach(() => {
     jest.clearAllMocks();
-    mockHttpClient.reset();
+    resetMockHttpClient();
   });
 
   describe('getSettings', () => {
@@ -33,7 +33,6 @@ describe('Management SSO', () => {
 
       expect(mockHttpClient.get).toHaveBeenCalledWith(apiPaths.sso.settings, {
         queryParams: { tenantId },
-        token: 'key',
       });
 
       expect(resp).toEqual({
@@ -62,7 +61,6 @@ describe('Management SSO', () => {
 
       expect(mockHttpClient.delete).toHaveBeenCalledWith(apiPaths.sso.settings, {
         queryParams: { tenantId },
-        token: 'key',
       });
 
       expect(resp).toEqual({
@@ -90,7 +88,6 @@ describe('Management SSO', () => {
 
       expect(mockHttpClient.delete).toHaveBeenCalledWith(apiPaths.sso.settings, {
         queryParams: { tenantId, ssoId },
-        token: 'key',
       });
 
       expect(resp).toEqual({
@@ -128,11 +125,14 @@ describe('Management SSO', () => {
         domains,
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.sso.settings,
-        { tenantId, idpURL, idpCert, entityId, redirectURL, domains },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.sso.settings, {
+        tenantId,
+        idpURL,
+        idpCert,
+        entityId,
+        redirectURL,
+        domains,
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -164,16 +164,12 @@ describe('Management SSO', () => {
         domains,
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.sso.metadata,
-        {
-          tenantId,
-          idpMetadataURL,
-          domains,
-          redirectURL,
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.sso.metadata, {
+        tenantId,
+        idpMetadataURL,
+        domains,
+        redirectURL,
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -200,15 +196,11 @@ describe('Management SSO', () => {
         { name: 'IDP_NAME', email: 'IDP_MAIL' },
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.sso.mapping,
-        {
-          tenantId: 't1',
-          roleMappings: [{ groups: ['g1', 'g2'], roleName: 'role1' }],
-          attributeMapping: { name: 'IDP_NAME', email: 'IDP_MAIL' },
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.sso.mapping, {
+        tenantId: 't1',
+        roleMappings: [{ groups: ['g1', 'g2'], roleName: 'role1' }],
+        attributeMapping: { name: 'IDP_NAME', email: 'IDP_MAIL' },
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -242,22 +234,18 @@ describe('Management SSO', () => {
         ['a.com', 'b.com'],
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.sso.oidc.configure,
-        {
-          tenantId: 't1',
-          settings: {
-            clientId: 'cid',
-            name: 'cn',
-            userAttrMapping: {
-              email: 'em',
-            },
-            redirectUrl: 'http://redirect.com',
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.sso.oidc.configure, {
+        tenantId: 't1',
+        settings: {
+          clientId: 'cid',
+          name: 'cn',
+          userAttrMapping: {
+            email: 'em',
           },
-          domains: ['a.com', 'b.com'],
+          redirectUrl: 'http://redirect.com',
         },
-        { token: 'key' },
-      );
+        domains: ['a.com', 'b.com'],
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -290,23 +278,19 @@ describe('Management SSO', () => {
         'somessoid',
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.sso.oidc.configure,
-        {
-          tenantId: 't1',
-          ssoId: 'somessoid',
-          settings: {
-            clientId: 'cid',
-            name: 'cn',
-            userAttrMapping: {
-              email: 'em',
-            },
-            redirectUrl: 'http://redirect.com',
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.sso.oidc.configure, {
+        tenantId: 't1',
+        ssoId: 'somessoid',
+        settings: {
+          clientId: 'cid',
+          name: 'cn',
+          userAttrMapping: {
+            email: 'em',
           },
-          domains: ['a.com', 'b.com'],
+          redirectUrl: 'http://redirect.com',
         },
-        { token: 'key' },
-      );
+        domains: ['a.com', 'b.com'],
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -341,23 +325,19 @@ describe('Management SSO', () => {
         ['a.com', 'b.com'],
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.sso.saml.configure,
-        {
-          tenantId: 't1',
-          settings: {
-            idpUrl: 'https://idp.url',
-            entityId: 'eid',
-            idpCert: 'bsae64cert',
-            spACSUrl: 'https://spacs.url',
-            spEntityId: 'spentityid',
-            defaultSSORoles: ['aa', 'bb'],
-          },
-          redirectUrl: 'http://redirect.com',
-          domains: ['a.com', 'b.com'],
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.sso.saml.configure, {
+        tenantId: 't1',
+        settings: {
+          idpUrl: 'https://idp.url',
+          entityId: 'eid',
+          idpCert: 'bsae64cert',
+          spACSUrl: 'https://spacs.url',
+          spEntityId: 'spentityid',
+          defaultSSORoles: ['aa', 'bb'],
         },
-        { token: 'key' },
-      );
+        redirectUrl: 'http://redirect.com',
+        domains: ['a.com', 'b.com'],
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -390,23 +370,19 @@ describe('Management SSO', () => {
         'somessoid',
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.sso.saml.configure,
-        {
-          tenantId: 't1',
-          ssoId: 'somessoid',
-          settings: {
-            idpUrl: 'https://idp.url',
-            entityId: 'eid',
-            idpCert: 'bsae64cert',
-            spACSUrl: 'https://spacs.url',
-            spEntityId: 'spentityid',
-          },
-          redirectUrl: 'http://redirect.com',
-          domains: ['a.com', 'b.com'],
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.sso.saml.configure, {
+        tenantId: 't1',
+        ssoId: 'somessoid',
+        settings: {
+          idpUrl: 'https://idp.url',
+          entityId: 'eid',
+          idpCert: 'bsae64cert',
+          spACSUrl: 'https://spacs.url',
+          spEntityId: 'spentityid',
         },
-        { token: 'key' },
-      );
+        redirectUrl: 'http://redirect.com',
+        domains: ['a.com', 'b.com'],
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -440,22 +416,18 @@ describe('Management SSO', () => {
         ['a.com', 'b.com'],
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.sso.saml.metadata,
-        {
-          tenantId: 't1',
-          settings: {
-            idpMetadataUrl: 'https://metadata.com',
-            attributeMapping: { name: 'IDP_NAME', email: 'IDP_MAIL' },
-            spACSUrl: 'https://spacs.url',
-            spEntityId: 'spentityid',
-            defaultSSORoles: ['aa', 'bb'],
-          },
-          redirectUrl: 'http://redirect.com',
-          domains: ['a.com', 'b.com'],
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.sso.saml.metadata, {
+        tenantId: 't1',
+        settings: {
+          idpMetadataUrl: 'https://metadata.com',
+          attributeMapping: { name: 'IDP_NAME', email: 'IDP_MAIL' },
+          spACSUrl: 'https://spacs.url',
+          spEntityId: 'spentityid',
+          defaultSSORoles: ['aa', 'bb'],
         },
-        { token: 'key' },
-      );
+        redirectUrl: 'http://redirect.com',
+        domains: ['a.com', 'b.com'],
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -487,22 +459,18 @@ describe('Management SSO', () => {
         'somessoid',
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.sso.saml.metadata,
-        {
-          tenantId: 't1',
-          ssoId: 'somessoid',
-          settings: {
-            idpMetadataUrl: 'https://metadata.com',
-            attributeMapping: { name: 'IDP_NAME', email: 'IDP_MAIL' },
-            spACSUrl: 'https://spacs.url',
-            spEntityId: 'spentityid',
-          },
-          redirectUrl: 'http://redirect.com',
-          domains: ['a.com', 'b.com'],
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.sso.saml.metadata, {
+        tenantId: 't1',
+        ssoId: 'somessoid',
+        settings: {
+          idpMetadataUrl: 'https://metadata.com',
+          attributeMapping: { name: 'IDP_NAME', email: 'IDP_MAIL' },
+          spACSUrl: 'https://spacs.url',
+          spEntityId: 'spentityid',
         },
-        { token: 'key' },
-      );
+        redirectUrl: 'http://redirect.com',
+        domains: ['a.com', 'b.com'],
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -540,15 +508,11 @@ describe('Management SSO', () => {
       mockHttpClient.post.mockResolvedValue(httpResponse);
       const resp = await management.sso.newSettings('t1', 'somessoid', 'somessodisplayname');
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.sso.settingsNew,
-        {
-          tenantId: 't1',
-          ssoId: 'somessoid',
-          displayName: 'somessodisplayname',
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.sso.settingsNew, {
+        tenantId: 't1',
+        ssoId: 'somessoid',
+        displayName: 'somessodisplayname',
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -604,7 +568,6 @@ describe('Management SSO', () => {
         queryParams: {
           tenantId: 't1',
         },
-        token: 'key',
       });
 
       expect(resp).toEqual({
@@ -659,7 +622,6 @@ describe('Management SSO', () => {
           tenantId: 't1',
           ssoId: 'somessoid',
         },
-        token: 'key',
       });
 
       expect(resp).toEqual({
@@ -720,7 +682,6 @@ describe('Management SSO', () => {
         queryParams: {
           tenantId: 't1',
         },
-        token: 'key',
       });
 
       expect(resp).toEqual({
@@ -770,7 +731,6 @@ describe('Management SSO', () => {
       queryParams: {
         tenantId: 't1',
       },
-      token: 'key',
     });
 
     expect(resp).toEqual({

--- a/lib/management/sso.ts
+++ b/lib/management/sso.ts
@@ -1,5 +1,4 @@
-import { SdkResponse, transformResponse } from '@descope/core-js-sdk';
-import { CoreSdk } from '../types';
+import { SdkResponse, transformResponse, HttpClient } from '@descope/core-js-sdk';
 import apiPaths from './paths';
 import {
   RoleMappings,
@@ -38,15 +37,14 @@ function transformAllSettingsResponse(data) {
   return res;
 }
 
-const withSSOSettings = (sdk: CoreSdk, managementKey?: string) => ({
+const withSSOSettings = (httpClient: HttpClient) => ({
   /**
    * @deprecated  Use loadSettings instead
    */
   getSettings: (tenantId: string): Promise<SdkResponse<SSOSettingsResponse>> =>
     transformResponse<SSOSettingsResponse>(
-      sdk.httpClient.get(apiPaths.sso.settings, {
+      httpClient.get(apiPaths.sso.settings, {
         queryParams: { tenantId },
-        token: managementKey,
       }),
       (data) => data,
     ),
@@ -56,18 +54,17 @@ const withSSOSettings = (sdk: CoreSdk, managementKey?: string) => ({
     displayName: string,
   ): Promise<SdkResponse<SSOSettings>> =>
     transformResponse<SSOSettings>(
-      sdk.httpClient.post(
-        apiPaths.sso.settingsNew,
-        { tenantId, ...(ssoId ? { ssoId } : {}), displayName },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.sso.settingsNew, {
+        tenantId,
+        ...(ssoId ? { ssoId } : {}),
+        displayName,
+      }),
       (data) => transformSettingsResponse(data),
     ),
   deleteSettings: (tenantId: string, ssoId?: string): Promise<SdkResponse<never>> =>
     transformResponse(
-      sdk.httpClient.delete(apiPaths.sso.settings, {
+      httpClient.delete(apiPaths.sso.settings, {
         queryParams: { tenantId, ...(ssoId ? { ssoId } : {}) },
-        token: managementKey,
       }),
     ),
   /**
@@ -82,11 +79,14 @@ const withSSOSettings = (sdk: CoreSdk, managementKey?: string) => ({
     domains: string[],
   ): Promise<SdkResponse<never>> =>
     transformResponse(
-      sdk.httpClient.post(
-        apiPaths.sso.settings,
-        { tenantId, idpURL, entityId, idpCert, redirectURL, domains },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.sso.settings, {
+        tenantId,
+        idpURL,
+        entityId,
+        idpCert,
+        redirectURL,
+        domains,
+      }),
     ),
   /**
    * @deprecated  Use configureSAMLByMetadata instead
@@ -98,11 +98,7 @@ const withSSOSettings = (sdk: CoreSdk, managementKey?: string) => ({
     domains: string[],
   ): Promise<SdkResponse<never>> =>
     transformResponse(
-      sdk.httpClient.post(
-        apiPaths.sso.metadata,
-        { tenantId, idpMetadataURL, redirectURL, domains },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.sso.metadata, { tenantId, idpMetadataURL, redirectURL, domains }),
     ),
   /**
    * @deprecated  Use configureSAMLSettings, configureSAMLByMetadata or configureOIDCSettings instead
@@ -113,11 +109,7 @@ const withSSOSettings = (sdk: CoreSdk, managementKey?: string) => ({
     attributeMapping?: AttributeMapping,
   ): Promise<SdkResponse<never>> =>
     transformResponse(
-      sdk.httpClient.post(
-        apiPaths.sso.mapping,
-        { tenantId, roleMappings, attributeMapping },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.sso.mapping, { tenantId, roleMappings, attributeMapping }),
     ),
   configureOIDCSettings: (
     tenantId: string,
@@ -128,16 +120,12 @@ const withSSOSettings = (sdk: CoreSdk, managementKey?: string) => ({
     const readySettings = { ...settings, userAttrMapping: settings.attributeMapping };
     delete readySettings.attributeMapping;
     return transformResponse(
-      sdk.httpClient.post(
-        apiPaths.sso.oidc.configure,
-        {
-          tenantId,
-          settings: readySettings,
-          domains,
-          ...(ssoId ? { ssoId } : {}),
-        },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.sso.oidc.configure, {
+        tenantId,
+        settings: readySettings,
+        domains,
+        ...(ssoId ? { ssoId } : {}),
+      }),
     );
   },
   configureSAMLSettings: (
@@ -148,11 +136,13 @@ const withSSOSettings = (sdk: CoreSdk, managementKey?: string) => ({
     ssoId?: string,
   ): Promise<SdkResponse<never>> =>
     transformResponse(
-      sdk.httpClient.post(
-        apiPaths.sso.saml.configure,
-        { tenantId, settings, redirectUrl, domains, ...(ssoId ? { ssoId } : {}) },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.sso.saml.configure, {
+        tenantId,
+        settings,
+        redirectUrl,
+        domains,
+        ...(ssoId ? { ssoId } : {}),
+      }),
     ),
   configureSAMLByMetadata: (
     tenantId: string,
@@ -162,25 +152,25 @@ const withSSOSettings = (sdk: CoreSdk, managementKey?: string) => ({
     ssoId?: string,
   ): Promise<SdkResponse<never>> =>
     transformResponse(
-      sdk.httpClient.post(
-        apiPaths.sso.saml.metadata,
-        { tenantId, settings, redirectUrl, domains, ...(ssoId ? { ssoId } : {}) },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.sso.saml.metadata, {
+        tenantId,
+        settings,
+        redirectUrl,
+        domains,
+        ...(ssoId ? { ssoId } : {}),
+      }),
     ),
   loadSettings: (tenantId: string, ssoId?: string): Promise<SdkResponse<SSOSettings>> =>
     transformResponse<SSOSettings>(
-      sdk.httpClient.get(apiPaths.sso.settingsv2, {
+      httpClient.get(apiPaths.sso.settingsv2, {
         queryParams: { tenantId, ...(ssoId ? { ssoId } : {}) },
-        token: managementKey,
       }),
       (data) => transformSettingsResponse(data),
     ),
   loadAllSettings: (tenantId: string): Promise<SdkResponse<SSOSettings[]>> =>
     transformResponse<SSOSettings[]>(
-      sdk.httpClient.get(apiPaths.sso.settingsAllV2, {
+      httpClient.get(apiPaths.sso.settingsAllV2, {
         queryParams: { tenantId },
-        token: managementKey,
       }),
       (data) => transformAllSettingsResponse(data),
     ),

--- a/lib/management/ssoapplication.test.ts
+++ b/lib/management/ssoapplication.test.ts
@@ -2,9 +2,9 @@ import { SdkResponse } from '@descope/core-js-sdk';
 import withManagement from '.';
 import apiPaths from './paths';
 import { CreateSSOApplicationResponse, SSOApplication } from './types';
-import { mockCoreSdk, mockHttpClient } from './testutils';
+import { mockHttpClient, resetMockHttpClient } from './testutils';
 
-const management = withManagement(mockCoreSdk, 'key');
+const management = withManagement(mockHttpClient);
 
 const mockSSOApplicationCreateResponse = {
   id: 'foo',
@@ -73,7 +73,7 @@ const mockAllSSOApplicationsResponse = {
 describe('Management SSOApplication', () => {
   afterEach(() => {
     jest.clearAllMocks();
-    mockHttpClient.reset();
+    resetMockHttpClient();
   });
 
   describe('createOidcApplication', () => {
@@ -95,19 +95,15 @@ describe('Management SSOApplication', () => {
           forceAuthentication: true,
         });
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.ssoApplication.oidcCreate,
-        {
-          name: 'name',
-          loginPageUrl: 'http://dummy.com',
-          id: undefined,
-          description: undefined,
-          enabled: true,
-          logo: undefined,
-          forceAuthentication: true,
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.ssoApplication.oidcCreate, {
+        name: 'name',
+        loginPageUrl: 'http://dummy.com',
+        id: undefined,
+        description: undefined,
+        enabled: true,
+        logo: undefined,
+        forceAuthentication: true,
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -141,31 +137,27 @@ describe('Management SSOApplication', () => {
           logoutRedirectUrl: 'http://dummy.com/logout',
         });
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.ssoApplication.samlCreate,
-        {
-          name: 'name',
-          loginPageUrl: 'http://dummy.com',
-          id: undefined,
-          description: undefined,
-          logo: undefined,
-          enabled: true,
-          useMetadataInfo: true,
-          metadataUrl: 'http://dummy.com/metadata',
-          entityId: undefined,
-          acsUrl: undefined,
-          certificate: undefined,
-          attributeMapping: undefined,
-          groupsMapping: undefined,
-          acsAllowedCallbacks: undefined,
-          subjectNameIdType: undefined,
-          subjectNameIdFormat: undefined,
-          defaultRelayState: 'rs',
-          forceAuthentication: true,
-          logoutRedirectUrl: 'http://dummy.com/logout',
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.ssoApplication.samlCreate, {
+        name: 'name',
+        loginPageUrl: 'http://dummy.com',
+        id: undefined,
+        description: undefined,
+        logo: undefined,
+        enabled: true,
+        useMetadataInfo: true,
+        metadataUrl: 'http://dummy.com/metadata',
+        entityId: undefined,
+        acsUrl: undefined,
+        certificate: undefined,
+        attributeMapping: undefined,
+        groupsMapping: undefined,
+        acsAllowedCallbacks: undefined,
+        subjectNameIdType: undefined,
+        subjectNameIdFormat: undefined,
+        defaultRelayState: 'rs',
+        forceAuthentication: true,
+        logoutRedirectUrl: 'http://dummy.com/logout',
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -195,28 +187,24 @@ describe('Management SSOApplication', () => {
           metadataUrl: 'http://dummy.com/metadata',
         });
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.ssoApplication.samlCreate,
-        {
-          name: 'name',
-          loginPageUrl: 'http://dummy.com',
-          id: undefined,
-          description: undefined,
-          logo: undefined,
-          enabled: false,
-          useMetadataInfo: true,
-          metadataUrl: 'http://dummy.com/metadata',
-          entityId: undefined,
-          acsUrl: undefined,
-          certificate: undefined,
-          attributeMapping: undefined,
-          groupsMapping: undefined,
-          acsAllowedCallbacks: undefined,
-          subjectNameIdType: undefined,
-          subjectNameIdFormat: undefined,
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.ssoApplication.samlCreate, {
+        name: 'name',
+        loginPageUrl: 'http://dummy.com',
+        id: undefined,
+        description: undefined,
+        logo: undefined,
+        enabled: false,
+        useMetadataInfo: true,
+        metadataUrl: 'http://dummy.com/metadata',
+        entityId: undefined,
+        acsUrl: undefined,
+        certificate: undefined,
+        attributeMapping: undefined,
+        groupsMapping: undefined,
+        acsAllowedCallbacks: undefined,
+        subjectNameIdType: undefined,
+        subjectNameIdFormat: undefined,
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -246,19 +234,15 @@ describe('Management SSOApplication', () => {
         enabled: false,
       });
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.ssoApplication.oidcUpdate,
-        {
-          id: 'app1',
-          name: 'name',
-          loginPageUrl: 'http://dummy.com',
-          description: undefined,
-          enabled: false,
-          logo: undefined,
-          forceAuthentication: undefined,
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.ssoApplication.oidcUpdate, {
+        id: 'app1',
+        name: 'name',
+        loginPageUrl: 'http://dummy.com',
+        description: undefined,
+        enabled: false,
+        logo: undefined,
+        forceAuthentication: undefined,
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -290,31 +274,27 @@ describe('Management SSOApplication', () => {
         entityId: 'ent1234',
       });
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.ssoApplication.samlUpdate,
-        {
-          id: 'app1',
-          name: 'name',
-          loginPageUrl: 'http://dummy.com',
-          description: undefined,
-          logo: undefined,
-          enabled: true,
-          useMetadataInfo: false,
-          metadataUrl: undefined,
-          entityId: 'ent1234',
-          acsUrl: undefined,
-          certificate: undefined,
-          attributeMapping: undefined,
-          groupsMapping: undefined,
-          acsAllowedCallbacks: undefined,
-          subjectNameIdType: undefined,
-          subjectNameIdFormat: undefined,
-          defaultRelayState: undefined,
-          forceAuthentication: undefined,
-          logoutRedirectUrl: undefined,
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.ssoApplication.samlUpdate, {
+        id: 'app1',
+        name: 'name',
+        loginPageUrl: 'http://dummy.com',
+        description: undefined,
+        logo: undefined,
+        enabled: true,
+        useMetadataInfo: false,
+        metadataUrl: undefined,
+        entityId: 'ent1234',
+        acsUrl: undefined,
+        certificate: undefined,
+        attributeMapping: undefined,
+        groupsMapping: undefined,
+        acsAllowedCallbacks: undefined,
+        subjectNameIdType: undefined,
+        subjectNameIdFormat: undefined,
+        defaultRelayState: undefined,
+        forceAuthentication: undefined,
+        logoutRedirectUrl: undefined,
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -339,11 +319,9 @@ describe('Management SSOApplication', () => {
 
       const resp = await management.ssoApplication.delete('app1');
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.ssoApplication.delete,
-        { id: 'app1' },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.ssoApplication.delete, {
+        id: 'app1',
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -372,7 +350,6 @@ describe('Management SSOApplication', () => {
 
       expect(mockHttpClient.get).toHaveBeenCalledWith(apiPaths.ssoApplication.load, {
         queryParams: { id: mockSSOApplications[0].id },
-        token: 'key',
       });
 
       expect(resp).toEqual({
@@ -398,9 +375,7 @@ describe('Management SSOApplication', () => {
 
       const resp: SdkResponse<SSOApplication[]> = await management.ssoApplication.loadAll();
 
-      expect(mockHttpClient.get).toHaveBeenCalledWith(apiPaths.ssoApplication.loadAll, {
-        token: 'key',
-      });
+      expect(mockHttpClient.get).toHaveBeenCalledWith(apiPaths.ssoApplication.loadAll, {});
 
       expect(resp).toEqual({
         code: 200,

--- a/lib/management/ssoapplication.ts
+++ b/lib/management/ssoapplication.ts
@@ -1,5 +1,4 @@
-import { SdkResponse, transformResponse } from '@descope/core-js-sdk';
-import { CoreSdk } from '../types';
+import { SdkResponse, transformResponse, HttpClient } from '@descope/core-js-sdk';
 import apiPaths from './paths';
 import {
   CreateSSOApplicationResponse,
@@ -12,70 +11,45 @@ type MultipleSSOApplicationResponse = {
   apps: SSOApplication[];
 };
 
-const withSSOApplication = (sdk: CoreSdk, managementKey?: string) => ({
+const withSSOApplication = (httpClient: HttpClient) => ({
   createOidcApplication: (
     options: OidcApplicationOptions,
   ): Promise<SdkResponse<CreateSSOApplicationResponse>> =>
     transformResponse(
-      sdk.httpClient.post(
-        apiPaths.ssoApplication.oidcCreate,
-        {
-          ...options,
-          enabled: options.enabled ?? true,
-        },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.ssoApplication.oidcCreate, {
+        ...options,
+        enabled: options.enabled ?? true,
+      }),
     ),
   createSamlApplication: (
     options: SamlApplicationOptions,
   ): Promise<SdkResponse<CreateSSOApplicationResponse>> =>
     transformResponse(
-      sdk.httpClient.post(
-        apiPaths.ssoApplication.samlCreate,
-        {
-          ...options,
-          enabled: options.enabled ?? true,
-        },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.ssoApplication.samlCreate, {
+        ...options,
+        enabled: options.enabled ?? true,
+      }),
     ),
   updateOidcApplication: (
     options: OidcApplicationOptions & { id: string },
   ): Promise<SdkResponse<never>> =>
-    transformResponse(
-      sdk.httpClient.post(
-        apiPaths.ssoApplication.oidcUpdate,
-        { ...options },
-        { token: managementKey },
-      ),
-    ),
+    transformResponse(httpClient.post(apiPaths.ssoApplication.oidcUpdate, { ...options })),
   updateSamlApplication: (
     options: SamlApplicationOptions & { id: string },
   ): Promise<SdkResponse<never>> =>
-    transformResponse(
-      sdk.httpClient.post(
-        apiPaths.ssoApplication.samlUpdate,
-        { ...options },
-        { token: managementKey },
-      ),
-    ),
+    transformResponse(httpClient.post(apiPaths.ssoApplication.samlUpdate, { ...options })),
   delete: (id: string): Promise<SdkResponse<never>> =>
-    transformResponse(
-      sdk.httpClient.post(apiPaths.ssoApplication.delete, { id }, { token: managementKey }),
-    ),
+    transformResponse(httpClient.post(apiPaths.ssoApplication.delete, { id })),
   load: (id: string): Promise<SdkResponse<SSOApplication>> =>
     transformResponse<SSOApplication, SSOApplication>(
-      sdk.httpClient.get(apiPaths.ssoApplication.load, {
+      httpClient.get(apiPaths.ssoApplication.load, {
         queryParams: { id },
-        token: managementKey,
       }),
       (data) => data,
     ),
   loadAll: (): Promise<SdkResponse<SSOApplication[]>> =>
     transformResponse<MultipleSSOApplicationResponse, SSOApplication[]>(
-      sdk.httpClient.get(apiPaths.ssoApplication.loadAll, {
-        token: managementKey,
-      }),
+      httpClient.get(apiPaths.ssoApplication.loadAll, {}),
       (data) => data.apps,
     ),
 });

--- a/lib/management/tenant.test.ts
+++ b/lib/management/tenant.test.ts
@@ -7,9 +7,9 @@ import {
   Tenant,
   TenantSettings,
 } from './types';
-import { mockCoreSdk, mockHttpClient } from './testutils';
+import { mockHttpClient, resetMockHttpClient } from './testutils';
 
-const management = withManagement(mockCoreSdk, 'key');
+const management = withManagement(mockHttpClient);
 
 const mockTenantCreateResponse = {
   tenantId: 'foo',
@@ -42,7 +42,7 @@ const mockAllTenantsResponse = {
 describe('Management Tenant', () => {
   afterEach(() => {
     jest.clearAllMocks();
-    mockHttpClient.reset();
+    resetMockHttpClient();
   });
 
   describe('create', () => {
@@ -65,17 +65,13 @@ describe('Management Tenant', () => {
         true,
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.tenant.create,
-        {
-          name: 'name',
-          selfProvisioningDomains: ['d1'],
-          customAttributes: { customAttr: 'value' },
-          enforceSSO: true,
-          disabled: true,
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.tenant.create, {
+        name: 'name',
+        selfProvisioningDomains: ['d1'],
+        customAttributes: { customAttr: 'value' },
+        enforceSSO: true,
+        disabled: true,
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -107,18 +103,14 @@ describe('Management Tenant', () => {
         true,
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.tenant.create,
-        {
-          id: 't1',
-          name: 'name',
-          selfProvisioningDomains: ['d1'],
-          customAttributes: { customAttr: 'value' },
-          enforceSSO: true,
-          disabled: true,
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.tenant.create, {
+        id: 't1',
+        name: 'name',
+        selfProvisioningDomains: ['d1'],
+        customAttributes: { customAttr: 'value' },
+        enforceSSO: true,
+        disabled: true,
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -150,18 +142,14 @@ describe('Management Tenant', () => {
         true,
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.tenant.update,
-        {
-          id: 't1',
-          name: 'name',
-          selfProvisioningDomains: ['d1'],
-          customAttributes: { customAttr: 'value' },
-          enforceSSO: true,
-          disabled: true,
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.tenant.update, {
+        id: 't1',
+        name: 'name',
+        selfProvisioningDomains: ['d1'],
+        customAttributes: { customAttr: 'value' },
+        enforceSSO: true,
+        disabled: true,
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -186,11 +174,10 @@ describe('Management Tenant', () => {
 
       const resp = await management.tenant.delete('t1', true);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.tenant.delete,
-        { id: 't1', cascade: true },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.tenant.delete, {
+        id: 't1',
+        cascade: true,
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -217,7 +204,6 @@ describe('Management Tenant', () => {
 
       expect(mockHttpClient.get).toHaveBeenCalledWith(apiPaths.tenant.load, {
         queryParams: { id: mockTenants[0].id },
-        token: 'key',
       });
 
       expect(resp).toEqual({
@@ -243,9 +229,7 @@ describe('Management Tenant', () => {
 
       const resp: SdkResponse<Tenant[]> = await management.tenant.loadAll();
 
-      expect(mockHttpClient.get).toHaveBeenCalledWith(apiPaths.tenant.loadAll, {
-        token: 'key',
-      });
+      expect(mockHttpClient.get).toHaveBeenCalledWith(apiPaths.tenant.loadAll, {});
 
       expect(resp).toEqual({
         code: 200,
@@ -272,7 +256,6 @@ describe('Management Tenant', () => {
 
       expect(mockHttpClient.get).toHaveBeenCalledWith(apiPaths.tenant.settings, {
         queryParams: { id: 'test' },
-        token: 'key',
       });
 
       expect(resp).toEqual({
@@ -304,9 +287,7 @@ describe('Management Tenant', () => {
       expect(mockHttpClient.post).toHaveBeenCalledWith(
         apiPaths.tenant.settings,
         { ...mockSettings, tenantId: 'test' },
-        {
-          token: 'key',
-        },
+        {},
       );
 
       expect(resp).toEqual({
@@ -338,9 +319,7 @@ describe('Management Tenant', () => {
       expect(mockHttpClient.post).toHaveBeenCalledWith(
         apiPaths.tenant.generateSSOConfigurationLink,
         { tenantId: 'test', expireTime: 60 * 60 * 24 },
-        {
-          token: 'key',
-        },
+        {},
       );
 
       expect(resp).toEqual({
@@ -382,9 +361,7 @@ describe('Management Tenant', () => {
           email: 'some-email@aa.com',
           templateId: 'some-template-id',
         },
-        {
-          token: 'key',
-        },
+        {},
       );
 
       expect(resp).toEqual({

--- a/lib/management/tenant.ts
+++ b/lib/management/tenant.ts
@@ -1,5 +1,4 @@
-import { SdkResponse, transformResponse } from '@descope/core-js-sdk';
-import { CoreSdk } from '../types';
+import { SdkResponse, transformResponse, HttpClient } from '@descope/core-js-sdk';
 import apiPaths from './paths';
 import {
   CreateTenantResponse,
@@ -13,7 +12,7 @@ type MultipleTenantResponse = {
   tenants: Tenant[];
 };
 
-const withTenant = (sdk: CoreSdk, managementKey?: string) => ({
+const withTenant = (httpClient: HttpClient) => ({
   create: (
     name: string,
     selfProvisioningDomains?: string[],
@@ -22,11 +21,13 @@ const withTenant = (sdk: CoreSdk, managementKey?: string) => ({
     disabled?: boolean,
   ): Promise<SdkResponse<CreateTenantResponse>> =>
     transformResponse(
-      sdk.httpClient.post(
-        apiPaths.tenant.create,
-        { name, selfProvisioningDomains, customAttributes, enforceSSO, disabled },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.tenant.create, {
+        name,
+        selfProvisioningDomains,
+        customAttributes,
+        enforceSSO,
+        disabled,
+      }),
     ),
   createWithId: (
     id: string,
@@ -37,11 +38,14 @@ const withTenant = (sdk: CoreSdk, managementKey?: string) => ({
     disabled?: boolean,
   ): Promise<SdkResponse<never>> =>
     transformResponse(
-      sdk.httpClient.post(
-        apiPaths.tenant.create,
-        { id, name, selfProvisioningDomains, customAttributes, enforceSSO, disabled },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.tenant.create, {
+        id,
+        name,
+        selfProvisioningDomains,
+        customAttributes,
+        enforceSSO,
+        disabled,
+      }),
     ),
   update: (
     id: string,
@@ -52,29 +56,27 @@ const withTenant = (sdk: CoreSdk, managementKey?: string) => ({
     disabled?: boolean,
   ): Promise<SdkResponse<never>> =>
     transformResponse(
-      sdk.httpClient.post(
-        apiPaths.tenant.update,
-        { id, name, selfProvisioningDomains, customAttributes, enforceSSO, disabled },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.tenant.update, {
+        id,
+        name,
+        selfProvisioningDomains,
+        customAttributes,
+        enforceSSO,
+        disabled,
+      }),
     ),
   delete: (id: string, cascade?: boolean): Promise<SdkResponse<never>> =>
-    transformResponse(
-      sdk.httpClient.post(apiPaths.tenant.delete, { id, cascade }, { token: managementKey }),
-    ),
+    transformResponse(httpClient.post(apiPaths.tenant.delete, { id, cascade })),
   load: (id: string): Promise<SdkResponse<Tenant>> =>
     transformResponse<Tenant, Tenant>(
-      sdk.httpClient.get(apiPaths.tenant.load, {
+      httpClient.get(apiPaths.tenant.load, {
         queryParams: { id },
-        token: managementKey,
       }),
       (data) => data,
     ),
   loadAll: (): Promise<SdkResponse<Tenant[]>> =>
     transformResponse<MultipleTenantResponse, Tenant[]>(
-      sdk.httpClient.get(apiPaths.tenant.loadAll, {
-        token: managementKey,
-      }),
+      httpClient.get(apiPaths.tenant.loadAll, {}),
       (data) => data.tenants,
     ),
   searchAll: (
@@ -84,36 +86,23 @@ const withTenant = (sdk: CoreSdk, managementKey?: string) => ({
     customAttributes?: Record<string, AttributesTypes>,
   ): Promise<SdkResponse<Tenant[]>> =>
     transformResponse<MultipleTenantResponse, Tenant[]>(
-      sdk.httpClient.post(
-        apiPaths.tenant.searchAll,
-        {
-          tenantIds: ids,
-          tenantNames: names,
-          tenantSelfProvisioningDomains: selfProvisioningDomains,
-          customAttributes,
-        },
-        { token: managementKey },
-      ),
+      httpClient.post(apiPaths.tenant.searchAll, {
+        tenantIds: ids,
+        tenantNames: names,
+        tenantSelfProvisioningDomains: selfProvisioningDomains,
+        customAttributes,
+      }),
       (data) => data.tenants,
     ),
   getSettings: (tenantId: string): Promise<SdkResponse<TenantSettings>> =>
     transformResponse<TenantSettings, TenantSettings>(
-      sdk.httpClient.get(apiPaths.tenant.settings, {
+      httpClient.get(apiPaths.tenant.settings, {
         queryParams: { id: tenantId },
-        token: managementKey,
       }),
       (data) => data,
     ),
   configureSettings: (tenantId: string, settings: TenantSettings): Promise<SdkResponse<never>> =>
-    transformResponse(
-      sdk.httpClient.post(
-        apiPaths.tenant.settings,
-        { ...settings, tenantId },
-        {
-          token: managementKey,
-        },
-      ),
-    ),
+    transformResponse(httpClient.post(apiPaths.tenant.settings, { ...settings, tenantId }, {})),
   generateSSOConfigurationLink: (
     tenantId: string,
     expireDuration: number,
@@ -122,12 +111,10 @@ const withTenant = (sdk: CoreSdk, managementKey?: string) => ({
     templateId?: string,
   ): Promise<SdkResponse<GenerateSSOConfigurationLinkResponse>> =>
     transformResponse<GenerateSSOConfigurationLinkResponse, GenerateSSOConfigurationLinkResponse>(
-      sdk.httpClient.post(
+      httpClient.post(
         apiPaths.tenant.generateSSOConfigurationLink,
         { tenantId, expireTime: expireDuration, ssoId, email, templateId },
-        {
-          token: managementKey,
-        },
+        {},
       ),
       (data) => data,
     ),

--- a/lib/management/testutils.ts
+++ b/lib/management/testutils.ts
@@ -1,3 +1,5 @@
+import { HttpClient } from '@descope/core-js-sdk';
+
 /* istanbul ignore file */
 const mockHttpClient = {
   get: jest.fn(),
@@ -5,20 +7,24 @@ const mockHttpClient = {
   patch: jest.fn(),
   put: jest.fn(),
   delete: jest.fn(),
-  reset: () =>
-    ['get', 'post', 'patch', 'put', 'delete'].forEach((key) =>
-      mockHttpClient[key].mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({ body: 'body' }),
-        clone: () => ({
-          json: () => Promise.resolve({ body: 'body' }),
-        }),
-        status: 200,
-      }),
-    ),
+  buildUrl(path, queryParams) {
+    return path + (queryParams ? '?' + new URLSearchParams(queryParams).toString() : '');
+  },
 };
-mockHttpClient.reset();
 
+export const resetMockHttpClient = () =>
+  ['get', 'post', 'patch', 'put', 'delete'].forEach((key) =>
+    mockHttpClient[key].mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ body: 'body' }),
+      clone: () => ({
+        json: () => Promise.resolve({ body: 'body' }),
+      }),
+      status: 200,
+    }),
+  );
+
+resetMockHttpClient();
 export { mockHttpClient };
 
 export const mockCoreSdk = {

--- a/lib/management/testutils.ts
+++ b/lib/management/testutils.ts
@@ -1,5 +1,3 @@
-import { HttpClient } from '@descope/core-js-sdk';
-
 /* istanbul ignore file */
 const mockHttpClient = {
   get: jest.fn(),
@@ -8,11 +6,11 @@ const mockHttpClient = {
   put: jest.fn(),
   delete: jest.fn(),
   buildUrl(path, queryParams) {
-    return path + (queryParams ? '?' + new URLSearchParams(queryParams).toString() : '');
+    return path + (queryParams ? `?${new URLSearchParams(queryParams).toString()}` : '');
   },
 };
 
-export const resetMockHttpClient = () =>
+const resetMockHttpClient = () =>
   ['get', 'post', 'patch', 'put', 'delete'].forEach((key) =>
     mockHttpClient[key].mockResolvedValue({
       ok: true,
@@ -25,8 +23,9 @@ export const resetMockHttpClient = () =>
   );
 
 resetMockHttpClient();
-export { mockHttpClient };
 
-export const mockCoreSdk = {
+const mockCoreSdk = {
   httpClient: mockHttpClient,
 } as any;
+
+export { resetMockHttpClient, mockHttpClient, mockCoreSdk };

--- a/lib/management/theme.ts
+++ b/lib/management/theme.ts
@@ -1,15 +1,12 @@
-import { SdkResponse, transformResponse } from '@descope/core-js-sdk';
-import { CoreSdk } from '../types';
+import { SdkResponse, transformResponse, HttpClient } from '@descope/core-js-sdk';
 import apiPaths from './paths';
 import { Theme, ThemeResponse } from './types';
 
-const WithTheme = (sdk: CoreSdk, managementKey?: string) => ({
+const WithTheme = (httpClient: HttpClient) => ({
   export: (): Promise<SdkResponse<ThemeResponse>> =>
-    transformResponse(sdk.httpClient.post(apiPaths.theme.export, {}, { token: managementKey })),
+    transformResponse(httpClient.post(apiPaths.theme.export, {})),
   import: (theme: Theme): Promise<SdkResponse<ThemeResponse>> =>
-    transformResponse(
-      sdk.httpClient.post(apiPaths.theme.import, { theme }, { token: managementKey }),
-    ),
+    transformResponse(httpClient.post(apiPaths.theme.import, { theme })),
 });
 
 export default WithTheme;

--- a/lib/management/user.test.ts
+++ b/lib/management/user.test.ts
@@ -1,7 +1,7 @@
 import { LoginOptions, SdkResponse, UserResponse } from '@descope/core-js-sdk';
 import withManagement from '.';
 import apiPaths from './paths';
-import { mockCoreSdk, mockHttpClient } from './testutils';
+import { mockHttpClient, resetMockHttpClient } from './testutils';
 import {
   GenerateOTPForTestResponse,
   GenerateMagicLinkForTestResponse,
@@ -12,7 +12,7 @@ import {
   UserPasswordHashed,
 } from './types';
 
-const management = withManagement(mockCoreSdk, 'key');
+const management = withManagement(mockHttpClient);
 
 const mockUserResponse = {
   name: 'foo',
@@ -39,7 +39,7 @@ const mockMgmtInviteBatchResponse = {
 describe('Management User', () => {
   afterEach(() => {
     jest.clearAllMocks();
-    mockHttpClient.reset();
+    resetMockHttpClient();
   });
 
   describe('create', () => {
@@ -71,20 +71,16 @@ describe('Management User', () => {
         ['id-1', 'id-2'],
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.create,
-        {
-          loginId: 'loginId',
-          email: 'a@b.c',
-          phone: null,
-          displayName: null,
-          roleNames: ['r1', 'r2'],
-          userTenants: null,
-          customAttributes: { a: 'a', b: 1, c: true },
-          additionalLoginIds: ['id-1', 'id-2'],
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.create, {
+        loginId: 'loginId',
+        email: 'a@b.c',
+        phone: null,
+        displayName: null,
+        roleNames: ['r1', 'r2'],
+        userTenants: null,
+        customAttributes: { a: 'a', b: 1, c: true },
+        additionalLoginIds: ['id-1', 'id-2'],
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -118,21 +114,17 @@ describe('Management User', () => {
         false,
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.create,
-        {
-          loginId: 'loginId',
-          email: 'a@b.c',
-          phone: null,
-          displayName: null,
-          roleNames: ['r1', 'r2'],
-          userTenants: null,
-          customAttributes: { a: 'a', b: 1, c: true },
-          verifiedEmail: true,
-          verifiedPhone: false,
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.create, {
+        loginId: 'loginId',
+        email: 'a@b.c',
+        phone: null,
+        displayName: null,
+        roleNames: ['r1', 'r2'],
+        userTenants: null,
+        customAttributes: { a: 'a', b: 1, c: true },
+        verifiedEmail: true,
+        verifiedPhone: false,
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -160,17 +152,13 @@ describe('Management User', () => {
         additionalLoginIds: ['id-1', 'id-2'],
       });
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.create,
-        {
-          loginId: 'loginId',
-          email: 'a@b.c',
-          roleNames: ['r1', 'r2'],
-          customAttributes: { a: 'a', b: 1, c: true },
-          additionalLoginIds: ['id-1', 'id-2'],
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.create, {
+        loginId: 'loginId',
+        email: 'a@b.c',
+        roleNames: ['r1', 'r2'],
+        customAttributes: { a: 'a', b: 1, c: true },
+        additionalLoginIds: ['id-1', 'id-2'],
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -203,20 +191,16 @@ describe('Management User', () => {
         { a: 'a', b: 1, c: true },
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.createTestUser,
-        {
-          loginId: 'loginId',
-          email: 'a@b.c',
-          phone: null,
-          displayName: null,
-          roleNames: ['r1', 'r2'],
-          test: true,
-          userTenants: null,
-          customAttributes: { a: 'a', b: 1, c: true },
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.createTestUser, {
+        loginId: 'loginId',
+        email: 'a@b.c',
+        phone: null,
+        displayName: null,
+        roleNames: ['r1', 'r2'],
+        test: true,
+        userTenants: null,
+        customAttributes: { a: 'a', b: 1, c: true },
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -243,17 +227,13 @@ describe('Management User', () => {
         customAttributes: { a: 'a', b: 1, c: true },
       });
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.createTestUser,
-        {
-          loginId: 'loginId',
-          email: 'a@b.c',
-          roleNames: ['r1', 'r2'],
-          test: true,
-          customAttributes: { a: 'a', b: 1, c: true },
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.createTestUser, {
+        loginId: 'loginId',
+        email: 'a@b.c',
+        roleNames: ['r1', 'r2'],
+        test: true,
+        customAttributes: { a: 'a', b: 1, c: true },
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -291,24 +271,20 @@ describe('Management User', () => {
         true,
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.create,
-        {
-          loginId: 'loginId',
-          email: 'a@b.c',
-          phone: null,
-          displayName: null,
-          roleNames: ['r1', 'r2'],
-          invite: true,
-          userTenants: null,
-          customAttributes: { a: 'a', b: 1, c: true },
-          verifiedEmail: false,
-          verifiedPhone: false,
-          inviteUrl: 'https://invite.me',
-          sendMail: true,
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.create, {
+        loginId: 'loginId',
+        email: 'a@b.c',
+        phone: null,
+        displayName: null,
+        roleNames: ['r1', 'r2'],
+        invite: true,
+        userTenants: null,
+        customAttributes: { a: 'a', b: 1, c: true },
+        verifiedEmail: false,
+        verifiedPhone: false,
+        inviteUrl: 'https://invite.me',
+        sendMail: true,
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -338,20 +314,16 @@ describe('Management User', () => {
         templateOptions: { k1: 'v1' },
       });
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.create,
-        {
-          loginId: 'loginId',
-          email: 'a@b.c',
-          roleNames: ['r1', 'r2'],
-          invite: true,
-          customAttributes: { a: 'a', b: 1, c: true },
-          inviteUrl: 'https://invite.me',
-          sendMail: true,
-          templateOptions: { k1: 'v1' },
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.create, {
+        loginId: 'loginId',
+        email: 'a@b.c',
+        roleNames: ['r1', 'r2'],
+        invite: true,
+        customAttributes: { a: 'a', b: 1, c: true },
+        inviteUrl: 'https://invite.me',
+        sendMail: true,
+        templateOptions: { k1: 'v1' },
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -394,39 +366,35 @@ describe('Management User', () => {
         true,
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.createBatch,
-        {
-          users: [
-            {
-              loginId: 'one',
-              roleNames: ['r1'],
-              email: 'one@one',
-              password: 'clear',
-              seed: 'aaa',
-            },
-            {
-              loginId: 'two',
-              roleNames: ['r1'],
-              email: 'two@two',
-              hashedPassword: {
-                firebase: {
-                  hash: 'h',
-                  salt: 's',
-                  saltSeparator: 'ss',
-                  signerKey: 'sk',
-                  memory: 14,
-                  rounds: 8,
-                },
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.createBatch, {
+        users: [
+          {
+            loginId: 'one',
+            roleNames: ['r1'],
+            email: 'one@one',
+            password: 'clear',
+            seed: 'aaa',
+          },
+          {
+            loginId: 'two',
+            roleNames: ['r1'],
+            email: 'two@two',
+            hashedPassword: {
+              firebase: {
+                hash: 'h',
+                salt: 's',
+                saltSeparator: 'ss',
+                signerKey: 'sk',
+                memory: 14,
+                rounds: 8,
               },
             },
-          ],
-          invite: true,
-          inviteUrl: 'https://invite.me',
-          sendMail: true,
-        },
-        { token: 'key' },
-      );
+          },
+        ],
+        invite: true,
+        inviteUrl: 'https://invite.me',
+        sendMail: true,
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -465,36 +433,32 @@ describe('Management User', () => {
         { loginId: 'two', roles: ['r1'], email: 'two@two', hashedPassword: hashed },
       ]);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.createBatch,
-        {
-          users: [
-            {
-              loginId: 'one',
-              roleNames: ['r1'],
-              email: 'one@one',
-              password: 'clear',
-              seed: 'aaa',
-            },
-            {
-              loginId: 'two',
-              roleNames: ['r1'],
-              email: 'two@two',
-              hashedPassword: {
-                firebase: {
-                  hash: 'h',
-                  salt: 's',
-                  saltSeparator: 'ss',
-                  signerKey: 'sk',
-                  memory: 14,
-                  rounds: 8,
-                },
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.createBatch, {
+        users: [
+          {
+            loginId: 'one',
+            roleNames: ['r1'],
+            email: 'one@one',
+            password: 'clear',
+            seed: 'aaa',
+          },
+          {
+            loginId: 'two',
+            roleNames: ['r1'],
+            email: 'two@two',
+            hashedPassword: {
+              firebase: {
+                hash: 'h',
+                salt: 's',
+                saltSeparator: 'ss',
+                signerKey: 'sk',
+                memory: 14,
+                rounds: 8,
               },
             },
-          ],
-        },
-        { token: 'key' },
-      );
+          },
+        ],
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -519,11 +483,10 @@ describe('Management User', () => {
 
       const resp: SdkResponse<UserResponse> = await management.user.update('loginId', 'a@b.c');
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.update,
-        { loginId: 'loginId', email: 'a@b.c' },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.update, {
+        loginId: 'loginId',
+        email: 'a@b.c',
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -548,11 +511,10 @@ describe('Management User', () => {
         email: 'a@b.c',
       });
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.update,
-        { loginId: 'loginId', email: 'a@b.c' },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.update, {
+        loginId: 'loginId',
+        email: 'a@b.c',
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -585,19 +547,15 @@ describe('Management User', () => {
         roles: ['r1', 'r2'],
       });
 
-      expect(mockHttpClient.patch).toHaveBeenCalledWith(
-        apiPaths.user.patch,
-        {
-          loginId: 'loginId',
-          email: 'a@b.c',
-          phone: '+11111111',
-          givenName: 'name1',
-          middleName: 'name2',
-          familyName: 'name3',
-          roleNames: ['r1', 'r2'],
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.patch).toHaveBeenCalledWith(apiPaths.user.patch, {
+        loginId: 'loginId',
+        email: 'a@b.c',
+        phone: '+11111111',
+        givenName: 'name1',
+        middleName: 'name2',
+        familyName: 'name3',
+        roleNames: ['r1', 'r2'],
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -619,21 +577,17 @@ describe('Management User', () => {
         ssoAppIds: ['sso1', 'sso2'],
       });
 
-      expect(mockHttpClient.patch).toHaveBeenCalledWith(
-        apiPaths.user.patch,
-        {
-          loginId: 'loginId',
-          displayName: 'name',
-          userTenants: [{ tenantId: 't1', roleNames: ['r1'] }],
-          customAttributes: { a: 'a', b: 1, c: true },
-          picture: 'pic',
-          verifiedEmail: true,
-          verifiedPhone: false,
-          ssoAppIds: ['sso1', 'sso2'],
-          scim: true,
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.patch).toHaveBeenCalledWith(apiPaths.user.patch, {
+        loginId: 'loginId',
+        displayName: 'name',
+        userTenants: [{ tenantId: 't1', roleNames: ['r1'] }],
+        customAttributes: { a: 'a', b: 1, c: true },
+        picture: 'pic',
+        verifiedEmail: true,
+        verifiedPhone: false,
+        ssoAppIds: ['sso1', 'sso2'],
+        scim: true,
+      });
     });
   });
 
@@ -651,11 +605,9 @@ describe('Management User', () => {
 
       const resp: SdkResponse<UserResponse> = await management.user.delete('loginId');
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.delete,
-        { loginId: 'loginId' },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.delete, {
+        loginId: 'loginId',
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -680,11 +632,7 @@ describe('Management User', () => {
 
       const resp: SdkResponse<UserResponse> = await management.user.deleteByUserId('userId');
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.delete,
-        { userId: 'userId' },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.delete, { userId: 'userId' });
 
       expect(resp).toEqual({
         code: 200,
@@ -709,11 +657,9 @@ describe('Management User', () => {
 
       const resp: SdkResponse<UserResponse> = await management.user.logoutUser('loginId');
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.logout,
-        { loginId: 'loginId' },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.logout, {
+        loginId: 'loginId',
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -736,11 +682,7 @@ describe('Management User', () => {
 
       const resp: SdkResponse<UserResponse> = await management.user.logoutUserByUserId('userId');
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.logout,
-        { userId: 'userId' },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.logout, { userId: 'userId' });
 
       expect(resp).toEqual({
         code: 200,
@@ -765,9 +707,7 @@ describe('Management User', () => {
 
       const resp: SdkResponse<never> = await management.user.deleteAllTestUsers();
 
-      expect(mockHttpClient.delete).toHaveBeenCalledWith(apiPaths.user.deleteAllTestUsers, {
-        token: 'key',
-      });
+      expect(mockHttpClient.delete).toHaveBeenCalledWith(apiPaths.user.deleteAllTestUsers);
 
       expect(resp).toEqual({
         code: 200,
@@ -794,7 +734,6 @@ describe('Management User', () => {
 
       expect(mockHttpClient.get).toHaveBeenCalledWith(apiPaths.user.load, {
         queryParams: { loginId: 'loginId' },
-        token: 'key',
       });
 
       expect(resp).toEqual({
@@ -822,7 +761,6 @@ describe('Management User', () => {
 
       expect(mockHttpClient.get).toHaveBeenCalledWith(apiPaths.user.load, {
         queryParams: { userId: 'userId' },
-        token: 'key',
       });
 
       expect(resp).toEqual({
@@ -859,18 +797,14 @@ describe('Management User', () => {
         ['+11111111'],
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.search,
-        {
-          tenantIds: ['t1'],
-          roleNames: ['r1'],
-          limit: 100,
-          statuses: ['enabled'],
-          emails: ['a@b.com'],
-          phones: ['+11111111'],
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.search, {
+        tenantIds: ['t1'],
+        roleNames: ['r1'],
+        limit: 100,
+        statuses: ['enabled'],
+        emails: ['a@b.com'],
+        phones: ['+11111111'],
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -910,28 +844,24 @@ describe('Management User', () => {
         tenantRoleNames: { tenant2: ['admin', 'user'] },
       });
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.searchTestUsers,
-        {
-          tenantIds: ['t1'],
-          roleNames: ['r1'],
-          limit: 100,
-          statuses: ['enabled'],
-          emails: ['a@b.com'],
-          phones: ['+11111111'],
-          text: 'some text',
-          fromCreatedTime: now,
-          toCreatedTime: now,
-          fromModifiedTime: now,
-          toModifiedTime: now,
-          withTestUser: true,
-          testUsersOnly: true,
-          sort: [{ field: 'aa', desc: true }, { field: 'bb' }],
-          tenantRoleIds: { tenant1: { values: ['roleA', 'roleB'] } },
-          tenantRoleNames: { tenant2: { values: ['admin', 'user'] } },
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.searchTestUsers, {
+        tenantIds: ['t1'],
+        roleNames: ['r1'],
+        limit: 100,
+        statuses: ['enabled'],
+        emails: ['a@b.com'],
+        phones: ['+11111111'],
+        text: 'some text',
+        fromCreatedTime: now,
+        toCreatedTime: now,
+        fromModifiedTime: now,
+        toModifiedTime: now,
+        withTestUser: true,
+        testUsersOnly: true,
+        sort: [{ field: 'aa', desc: true }, { field: 'bb' }],
+        tenantRoleIds: { tenant1: { values: ['roleA', 'roleB'] } },
+        tenantRoleNames: { tenant2: { values: ['admin', 'user'] } },
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -971,26 +901,22 @@ describe('Management User', () => {
         tenantRoleNames: { tenant2: ['admin', 'user'] },
       });
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.search,
-        {
-          tenantIds: ['t1'],
-          roleNames: ['r1'],
-          limit: 100,
-          statuses: ['enabled'],
-          emails: ['a@b.com'],
-          phones: ['+11111111'],
-          text: 'some text',
-          fromCreatedTime: now,
-          toCreatedTime: now,
-          fromModifiedTime: now,
-          toModifiedTime: now,
-          sort: [{ field: 'aa', desc: true }, { field: 'bb' }],
-          tenantRoleIds: { tenant1: { values: ['roleA', 'roleB'] } },
-          tenantRoleNames: { tenant2: { values: ['admin', 'user'] } },
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.search, {
+        tenantIds: ['t1'],
+        roleNames: ['r1'],
+        limit: 100,
+        statuses: ['enabled'],
+        emails: ['a@b.com'],
+        phones: ['+11111111'],
+        text: 'some text',
+        fromCreatedTime: now,
+        toCreatedTime: now,
+        fromModifiedTime: now,
+        toModifiedTime: now,
+        sort: [{ field: 'aa', desc: true }, { field: 'bb' }],
+        tenantRoleIds: { tenant1: { values: ['roleA', 'roleB'] } },
+        tenantRoleNames: { tenant2: { values: ['admin', 'user'] } },
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -1026,7 +952,6 @@ describe('Management User', () => {
           withRefreshToken: 'false',
           forceRefresh: 'false',
         },
-        token: 'key',
       });
 
       expect(resp).toEqual({
@@ -1061,7 +986,6 @@ describe('Management User', () => {
           withRefreshToken: 'true',
           forceRefresh: 'true',
         },
-        token: 'key',
       });
 
       expect(resp).toEqual({
@@ -1087,11 +1011,10 @@ describe('Management User', () => {
 
       const resp: SdkResponse<UserResponse> = await management.user.activate('lid');
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.updateStatus,
-        { loginId: 'lid', status: 'enabled' },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.updateStatus, {
+        loginId: 'lid',
+        status: 'enabled',
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -1116,11 +1039,10 @@ describe('Management User', () => {
 
       const resp: SdkResponse<UserResponse> = await management.user.deactivate('lid');
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.updateStatus,
-        { loginId: 'lid', status: 'disabled' },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.updateStatus, {
+        loginId: 'lid',
+        status: 'disabled',
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -1145,11 +1067,10 @@ describe('Management User', () => {
 
       const resp: SdkResponse<UserResponse> = await management.user.updateLoginId('lid', 'a@b.c');
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.updateLoginId,
-        { loginId: 'lid', newLoginId: 'a@b.c' },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.updateLoginId, {
+        loginId: 'lid',
+        newLoginId: 'a@b.c',
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -1178,11 +1099,11 @@ describe('Management User', () => {
         true,
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.updateEmail,
-        { loginId: 'lid', email: 'a@b.c', verified: true },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.updateEmail, {
+        loginId: 'lid',
+        email: 'a@b.c',
+        verified: true,
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -1211,11 +1132,11 @@ describe('Management User', () => {
         true,
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.updatePhone,
-        { loginId: 'lid', phone: '1234', verified: true },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.updatePhone, {
+        loginId: 'lid',
+        phone: '1234',
+        verified: true,
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -1240,11 +1161,10 @@ describe('Management User', () => {
 
       const resp: SdkResponse<UserResponse> = await management.user.updateDisplayName('lid', 'foo');
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.updateDisplayName,
-        { loginId: 'lid', displayName: 'foo' },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.updateDisplayName, {
+        loginId: 'lid',
+        displayName: 'foo',
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -1269,11 +1189,10 @@ describe('Management User', () => {
 
       const resp: SdkResponse<UserResponse> = await management.user.updatePicture('lid', 'foo');
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.updatePicture,
-        { loginId: 'lid', picture: 'foo' },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.updatePicture, {
+        loginId: 'lid',
+        picture: 'foo',
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -1302,11 +1221,11 @@ describe('Management User', () => {
         'bar',
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.updateCustomAttribute,
-        { loginId: 'lid', attributeKey: 'foo', attributeValue: 'bar' },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.updateCustomAttribute, {
+        loginId: 'lid',
+        attributeKey: 'foo',
+        attributeValue: 'bar',
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -1331,11 +1250,10 @@ describe('Management User', () => {
 
       const resp: SdkResponse<UserResponse> = await management.user.setRoles('lid', ['foo', 'bar']);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.setRole,
-        { loginId: 'lid', roleNames: ['foo', 'bar'] },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.setRole, {
+        loginId: 'lid',
+        roleNames: ['foo', 'bar'],
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -1360,11 +1278,10 @@ describe('Management User', () => {
 
       const resp: SdkResponse<UserResponse> = await management.user.addRoles('lid', ['foo', 'bar']);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.addRole,
-        { loginId: 'lid', roleNames: ['foo', 'bar'] },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.addRole, {
+        loginId: 'lid',
+        roleNames: ['foo', 'bar'],
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -1392,11 +1309,10 @@ describe('Management User', () => {
         'bar',
       ]);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.removeRole,
-        { loginId: 'lid', roleNames: ['foo', 'bar'] },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.removeRole, {
+        loginId: 'lid',
+        roleNames: ['foo', 'bar'],
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -1424,11 +1340,10 @@ describe('Management User', () => {
         'bar',
       ]);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.setSSOApps,
-        { loginId: 'lid', ssoAppIds: ['foo', 'bar'] },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.setSSOApps, {
+        loginId: 'lid',
+        ssoAppIds: ['foo', 'bar'],
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -1456,11 +1371,10 @@ describe('Management User', () => {
         'bar',
       ]);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.addSSOApps,
-        { loginId: 'lid', ssoAppIds: ['foo', 'bar'] },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.addSSOApps, {
+        loginId: 'lid',
+        ssoAppIds: ['foo', 'bar'],
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -1488,11 +1402,10 @@ describe('Management User', () => {
         'bar',
       ]);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.removeSSOApps,
-        { loginId: 'lid', ssoAppIds: ['foo', 'bar'] },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.removeSSOApps, {
+        loginId: 'lid',
+        ssoAppIds: ['foo', 'bar'],
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -1517,11 +1430,10 @@ describe('Management User', () => {
 
       const resp: SdkResponse<UserResponse> = await management.user.addTenant('lid', 'tid');
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.addTenant,
-        { loginId: 'lid', tenantId: 'tid' },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.addTenant, {
+        loginId: 'lid',
+        tenantId: 'tid',
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -1546,11 +1458,10 @@ describe('Management User', () => {
 
       const resp: SdkResponse<UserResponse> = await management.user.removeTenant('lid', 'tid');
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.removeTenant,
-        { loginId: 'lid', tenantId: 'tid' },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.removeTenant, {
+        loginId: 'lid',
+        tenantId: 'tid',
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -1578,11 +1489,11 @@ describe('Management User', () => {
         'bar',
       ]);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.setRole,
-        { loginId: 'lid', tenantId: 'tid', roleNames: ['foo', 'bar'] },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.setRole, {
+        loginId: 'lid',
+        tenantId: 'tid',
+        roleNames: ['foo', 'bar'],
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -1610,11 +1521,11 @@ describe('Management User', () => {
         'bar',
       ]);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.addRole,
-        { loginId: 'lid', tenantId: 'tid', roleNames: ['foo', 'bar'] },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.addRole, {
+        loginId: 'lid',
+        tenantId: 'tid',
+        roleNames: ['foo', 'bar'],
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -1643,11 +1554,11 @@ describe('Management User', () => {
         ['foo', 'bar'],
       );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.removeRole,
-        { loginId: 'lid', tenantId: 'tid', roleNames: ['foo', 'bar'] },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.removeRole, {
+        loginId: 'lid',
+        tenantId: 'tid',
+        roleNames: ['foo', 'bar'],
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -1677,11 +1588,11 @@ describe('Management User', () => {
       const resp: SdkResponse<GenerateOTPForTestResponse> =
         await management.user.generateOTPForTestUser('sms', 'some-id', loginOptions);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.generateOTPForTest,
-        { loginId: 'some-id', deliveryMethod: 'sms', loginOptions },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.generateOTPForTest, {
+        loginId: 'some-id',
+        deliveryMethod: 'sms',
+        loginOptions,
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -1709,11 +1620,11 @@ describe('Management User', () => {
       const resp: SdkResponse<GenerateOTPForTestResponse> =
         await management.user.generateOTPForTestUser('voice', 'some-id', loginOptions);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.generateOTPForTest,
-        { loginId: 'some-id', deliveryMethod: 'voice', loginOptions },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.generateOTPForTest, {
+        loginId: 'some-id',
+        deliveryMethod: 'voice',
+        loginOptions,
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -1741,11 +1652,11 @@ describe('Management User', () => {
       const resp: SdkResponse<GenerateOTPForTestResponse> =
         await management.user.generateOTPForTestUser('Embedded', 'some-id', loginOptions);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.generateOTPForTest,
-        { loginId: 'some-id', deliveryMethod: 'Embedded', loginOptions },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.generateOTPForTest, {
+        loginId: 'some-id',
+        deliveryMethod: 'Embedded',
+        loginOptions,
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -1780,11 +1691,12 @@ describe('Management User', () => {
           loginOptions,
         );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.generateMagicLinkForTest,
-        { loginId: 'some-id', deliveryMethod: 'email', URI: 'some-uri', loginOptions },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.generateMagicLinkForTest, {
+        loginId: 'some-id',
+        deliveryMethod: 'email',
+        URI: 'some-uri',
+        loginOptions,
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -1818,11 +1730,11 @@ describe('Management User', () => {
       const resp: SdkResponse<GenerateEnchantedLinkForTestResponse> =
         await management.user.generateEnchantedLinkForTestUser('some-id', 'some-uri', loginOptions);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.generateEnchantedLinkForTest,
-        { loginId: 'some-id', URI: 'some-uri', loginOptions },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.generateEnchantedLinkForTest, {
+        loginId: 'some-id',
+        URI: 'some-uri',
+        loginOptions,
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -1851,11 +1763,10 @@ describe('Management User', () => {
       const resp: SdkResponse<GenerateEmbeddedLinkResponse> =
         await management.user.generateEmbeddedLink('some-id', { k1: 'v1' });
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.generateEmbeddedLink,
-        { loginId: 'some-id', customClaims: { k1: 'v1' } },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.generateEmbeddedLink, {
+        loginId: 'some-id',
+        customClaims: { k1: 'v1' },
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -1891,18 +1802,14 @@ describe('Management User', () => {
           12,
         );
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.generateSignUpEmbeddedLink,
-        {
-          loginId: 'some-id',
-          user: { name: 'John Doe' },
-          emailVerified: true,
-          phoneVerified: true,
-          loginOptions: { mfa: true },
-          timeout: 12,
-        },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.generateSignUpEmbeddedLink, {
+        loginId: 'some-id',
+        user: { name: 'John Doe' },
+        emailVerified: true,
+        phoneVerified: true,
+        loginOptions: { mfa: true },
+        timeout: 12,
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -1929,11 +1836,10 @@ describe('Management User', () => {
       const password = 'some-password';
       const resp = await management.user.setPassword(loginId, password);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.setPassword,
-        { loginId, password },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.setPassword, {
+        loginId,
+        password,
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -1959,11 +1865,10 @@ describe('Management User', () => {
     const password = 'some-password';
     const resp = await management.user.setTemporaryPassword(loginId, password);
 
-    expect(mockHttpClient.post).toHaveBeenCalledWith(
-      apiPaths.user.setTemporaryPassword,
-      { loginId, password },
-      { token: 'key' },
-    );
+    expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.setTemporaryPassword, {
+      loginId,
+      password,
+    });
 
     expect(resp).toEqual({
       code: 200,
@@ -1988,11 +1893,10 @@ describe('Management User', () => {
     const password = 'some-password';
     const resp = await management.user.setActivePassword(loginId, password);
 
-    expect(mockHttpClient.post).toHaveBeenCalledWith(
-      apiPaths.user.setActivePassword,
-      { loginId, password },
-      { token: 'key' },
-    );
+    expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.setActivePassword, {
+      loginId,
+      password,
+    });
 
     expect(resp).toEqual({
       code: 200,
@@ -2017,11 +1921,7 @@ describe('Management User', () => {
       const loginId = 'some-id';
       const resp = await management.user.expirePassword(loginId);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.expirePassword,
-        { loginId },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.expirePassword, { loginId });
 
       expect(resp).toEqual({
         code: 200,
@@ -2047,11 +1947,9 @@ describe('Management User', () => {
       const loginId = 'some-id';
       const resp = await management.user.removeAllPasskeys(loginId);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.removeAllPasskeys,
-        { loginId },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.removeAllPasskeys, {
+        loginId,
+      });
 
       expect(resp).toEqual({
         code: 200,
@@ -2077,11 +1975,7 @@ describe('Management User', () => {
       const loginId = 'some-id';
       const resp = await management.user.removeTOTPSeed(loginId);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.user.removeTOTPSeed,
-        { loginId },
-        { token: 'key' },
-      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.removeTOTPSeed, { loginId });
 
       expect(resp).toEqual({
         code: 200,
@@ -2123,9 +2017,7 @@ describe('Management User', () => {
       const userIds = ['some-id-1', 'some-id-2'];
       const resp = await management.user.history(userIds);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.history, userIds, {
-        token: 'key',
-      });
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.history, userIds);
 
       expect(resp).toEqual({
         code: 200,

--- a/lib/management/user.ts
+++ b/lib/management/user.ts
@@ -1,4 +1,5 @@
 import {
+  HttpClient,
   SdkResponse,
   transformResponse,
   UserHistoryResponse,
@@ -20,7 +21,7 @@ import {
   ProviderTokenOptions,
   UserOptions,
 } from './types';
-import { CoreSdk, DeliveryMethodForTestUser } from '../types';
+import { DeliveryMethodForTestUser } from '../types';
 import apiPaths from './paths';
 import { transformUsersForBatch } from './helpers';
 
@@ -72,7 +73,7 @@ function mapToValuesObject(
   ) as Record<string, { values: string[] }>;
 }
 
-const withUser = (sdk: CoreSdk, managementKey?: string) => {
+const withUser = (httpClient: HttpClient) => {
   /* Create User */
   function create(loginId: string, options?: UserOptions): Promise<SdkResponse<UserResponse>>;
   function create(
@@ -136,7 +137,7 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
             roles: undefined,
           };
     return transformResponse<SingleUserResponse, UserResponse>(
-      sdk.httpClient.post(apiPaths.user.create, body, { token: managementKey }),
+      httpClient.post(apiPaths.user.create, body),
       (data) => data.user,
     );
   }
@@ -210,7 +211,7 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
             test: true,
           };
     return transformResponse<SingleUserResponse, UserResponse>(
-      sdk.httpClient.post(apiPaths.user.createTestUser, body, { token: managementKey }),
+      httpClient.post(apiPaths.user.createTestUser, body),
       (data) => data.user,
     );
   }
@@ -302,7 +303,7 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
             invite: true,
           };
     return transformResponse<SingleUserResponse, UserResponse>(
-      sdk.httpClient.post(apiPaths.user.create, body, { token: managementKey }),
+      httpClient.post(apiPaths.user.create, body),
       (data) => data.user,
     );
   }
@@ -371,7 +372,7 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
             roles: undefined,
           };
     return transformResponse<SingleUserResponse, UserResponse>(
-      sdk.httpClient.post(apiPaths.user.update, body, { token: managementKey }),
+      httpClient.post(apiPaths.user.update, body),
       (data) => data.user,
     );
   }
@@ -431,7 +432,7 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
     }
 
     return transformResponse<SingleUserResponse, UserResponse>(
-      sdk.httpClient.patch(apiPaths.user.patch, body, { token: managementKey }),
+      httpClient.patch(apiPaths.user.patch, body),
       (data) => data.user,
     );
   }
@@ -459,30 +460,22 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
       templateId?: string,
     ): Promise<SdkResponse<CreateOrInviteBatchResponse>> =>
       transformResponse<CreateOrInviteBatchResponse, CreateOrInviteBatchResponse>(
-        sdk.httpClient.post(
-          apiPaths.user.createBatch,
-          {
-            users: transformUsersForBatch(users),
-            invite: true,
-            inviteUrl,
-            sendMail,
-            sendSMS,
-            templateOptions,
-            templateId,
-          },
-          { token: managementKey },
-        ),
+        httpClient.post(apiPaths.user.createBatch, {
+          users: transformUsersForBatch(users),
+          invite: true,
+          inviteUrl,
+          sendMail,
+          sendSMS,
+          templateOptions,
+          templateId,
+        }),
         (data) => data,
       ),
     createBatch: (users: User[]): Promise<SdkResponse<CreateOrInviteBatchResponse>> =>
       transformResponse<CreateOrInviteBatchResponse, CreateOrInviteBatchResponse>(
-        sdk.httpClient.post(
-          apiPaths.user.createBatch,
-          {
-            users: transformUsersForBatch(users),
-          },
-          { token: managementKey },
-        ),
+        httpClient.post(apiPaths.user.createBatch, {
+          users: transformUsersForBatch(users),
+        }),
         (data) => data,
       ),
     update,
@@ -492,30 +485,23 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
      * @param loginId The login ID of the user
      */
     delete: (loginId: string): Promise<SdkResponse<never>> =>
-      transformResponse(
-        sdk.httpClient.post(apiPaths.user.delete, { loginId }, { token: managementKey }),
-      ),
+      transformResponse(httpClient.post(apiPaths.user.delete, { loginId })),
     /**
      * Delete an existing user by User ID.
      * @param userId The user ID can be found in the Subject (`sub`) claim
      * in the user's JWT.
      */
     deleteByUserId: (userId: string): Promise<SdkResponse<UserResponse>> =>
-      transformResponse(
-        sdk.httpClient.post(apiPaths.user.delete, { userId }, { token: managementKey }),
-      ),
+      transformResponse(httpClient.post(apiPaths.user.delete, { userId })),
     /**
      * Delete all test users in the project.
      */
     deleteAllTestUsers: (): Promise<SdkResponse<never>> =>
-      transformResponse(
-        sdk.httpClient.delete(apiPaths.user.deleteAllTestUsers, { token: managementKey }),
-      ),
+      transformResponse(httpClient.delete(apiPaths.user.deleteAllTestUsers)),
     load: (loginId: string): Promise<SdkResponse<UserResponse>> =>
       transformResponse<SingleUserResponse, UserResponse>(
-        sdk.httpClient.get(apiPaths.user.load, {
+        httpClient.get(apiPaths.user.load, {
           queryParams: { loginId },
-          token: managementKey,
         }),
         (data) => data.user,
       ),
@@ -527,9 +513,8 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
      */
     loadByUserId: (userId: string): Promise<SdkResponse<UserResponse>> =>
       transformResponse<SingleUserResponse, UserResponse>(
-        sdk.httpClient.get(apiPaths.user.load, {
+        httpClient.get(apiPaths.user.load, {
           queryParams: { userId },
-          token: managementKey,
         }),
         (data) => data.user,
       ),
@@ -539,9 +524,7 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
      * @returns The UserResponse if found, throws otherwise.
      */
     logoutUser: (loginId: string): Promise<SdkResponse<never>> =>
-      transformResponse(
-        sdk.httpClient.post(apiPaths.user.logout, { loginId }, { token: managementKey }),
-      ),
+      transformResponse(httpClient.post(apiPaths.user.logout, { loginId })),
     /**
      * Logout a user from all devices by user ID. The ID can be found
      * on the user's JWT.
@@ -549,9 +532,7 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
      * @returns The UserResponse if found, throws otherwise.
      */
     logoutUserByUserId: (userId: string): Promise<SdkResponse<never>> =>
-      transformResponse(
-        sdk.httpClient.post(apiPaths.user.logout, { userId }, { token: managementKey }),
-      ),
+      transformResponse(httpClient.post(apiPaths.user.logout, { userId })),
     /**
      * Search all users. Results can be filtered according to tenants and/or
      * roles, and also paginated used the limit and page parameters.
@@ -577,54 +558,42 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
       phones?: string[],
     ): Promise<SdkResponse<UserResponse[]>> =>
       transformResponse<MultipleUsersResponse, UserResponse[]>(
-        sdk.httpClient.post(
-          apiPaths.user.search,
-          {
-            tenantIds,
-            roleNames: roles,
-            limit,
-            page,
-            testUsersOnly,
-            withTestUser,
-            customAttributes,
-            statuses,
-            emails,
-            phones,
-          },
-          { token: managementKey },
-        ),
+        httpClient.post(apiPaths.user.search, {
+          tenantIds,
+          roleNames: roles,
+          limit,
+          page,
+          testUsersOnly,
+          withTestUser,
+          customAttributes,
+          statuses,
+          emails,
+          phones,
+        }),
         (data) => data.users,
       ),
     searchTestUsers: (searchReq: SearchRequest): Promise<SdkResponse<UserResponse[]>> =>
       transformResponse<MultipleUsersResponse, UserResponse[]>(
-        sdk.httpClient.post(
-          apiPaths.user.searchTestUsers,
-          {
-            ...searchReq,
-            withTestUser: true,
-            testUsersOnly: true,
-            roleNames: searchReq.roles,
-            roles: undefined,
-            tenantRoleIds: mapToValuesObject(searchReq.tenantRoleIds),
-            tenantRoleNames: mapToValuesObject(searchReq.tenantRoleNames),
-          },
-          { token: managementKey },
-        ),
+        httpClient.post(apiPaths.user.searchTestUsers, {
+          ...searchReq,
+          withTestUser: true,
+          testUsersOnly: true,
+          roleNames: searchReq.roles,
+          roles: undefined,
+          tenantRoleIds: mapToValuesObject(searchReq.tenantRoleIds),
+          tenantRoleNames: mapToValuesObject(searchReq.tenantRoleNames),
+        }),
         (data) => data.users,
       ),
     search: (searchReq: SearchRequest): Promise<SdkResponse<UserResponse[]>> =>
       transformResponse<MultipleUsersResponse, UserResponse[]>(
-        sdk.httpClient.post(
-          apiPaths.user.search,
-          {
-            ...searchReq,
-            roleNames: searchReq.roles,
-            roles: undefined,
-            tenantRoleIds: mapToValuesObject(searchReq.tenantRoleIds),
-            tenantRoleNames: mapToValuesObject(searchReq.tenantRoleNames),
-          },
-          { token: managementKey },
-        ),
+        httpClient.post(apiPaths.user.search, {
+          ...searchReq,
+          roleNames: searchReq.roles,
+          roles: undefined,
+          tenantRoleIds: mapToValuesObject(searchReq.tenantRoleIds),
+          tenantRoleNames: mapToValuesObject(searchReq.tenantRoleNames),
+        }),
         (data) => data.users,
       ),
     /**
@@ -644,42 +613,29 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
       providerTokenOptions?: ProviderTokenOptions,
     ): Promise<SdkResponse<ProviderTokenResponse>> =>
       transformResponse<ProviderTokenResponse>(
-        sdk.httpClient.get(apiPaths.user.getProviderToken, {
+        httpClient.get(apiPaths.user.getProviderToken, {
           queryParams: {
             loginId,
             provider,
             withRefreshToken: providerTokenOptions?.withRefreshToken ? 'true' : 'false',
             forceRefresh: providerTokenOptions?.forceRefresh ? 'true' : 'false',
           },
-          token: managementKey,
         }),
         (data) => data,
       ),
     activate: (loginId: string): Promise<SdkResponse<UserResponse>> =>
       transformResponse<SingleUserResponse, UserResponse>(
-        sdk.httpClient.post(
-          apiPaths.user.updateStatus,
-          { loginId, status: 'enabled' },
-          { token: managementKey },
-        ),
+        httpClient.post(apiPaths.user.updateStatus, { loginId, status: 'enabled' }),
         (data) => data.user,
       ),
     deactivate: (loginId: string): Promise<SdkResponse<UserResponse>> =>
       transformResponse<SingleUserResponse, UserResponse>(
-        sdk.httpClient.post(
-          apiPaths.user.updateStatus,
-          { loginId, status: 'disabled' },
-          { token: managementKey },
-        ),
+        httpClient.post(apiPaths.user.updateStatus, { loginId, status: 'disabled' }),
         (data) => data.user,
       ),
     updateLoginId: (loginId: string, newLoginId?: string): Promise<SdkResponse<UserResponse>> =>
       transformResponse<SingleUserResponse, UserResponse>(
-        sdk.httpClient.post(
-          apiPaths.user.updateLoginId,
-          { loginId, newLoginId },
-          { token: managementKey },
-        ),
+        httpClient.post(apiPaths.user.updateLoginId, { loginId, newLoginId }),
         (data) => data.user,
       ),
     updateEmail: (
@@ -688,11 +644,7 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
       isVerified: boolean,
     ): Promise<SdkResponse<UserResponse>> =>
       transformResponse<SingleUserResponse, UserResponse>(
-        sdk.httpClient.post(
-          apiPaths.user.updateEmail,
-          { loginId, email, verified: isVerified },
-          { token: managementKey },
-        ),
+        httpClient.post(apiPaths.user.updateEmail, { loginId, email, verified: isVerified }),
         (data) => data.user,
       ),
     updatePhone: (
@@ -701,11 +653,7 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
       isVerified: boolean,
     ): Promise<SdkResponse<UserResponse>> =>
       transformResponse<SingleUserResponse, UserResponse>(
-        sdk.httpClient.post(
-          apiPaths.user.updatePhone,
-          { loginId, phone, verified: isVerified },
-          { token: managementKey },
-        ),
+        httpClient.post(apiPaths.user.updatePhone, { loginId, phone, verified: isVerified }),
         (data) => data.user,
       ),
     updateDisplayName: (
@@ -716,20 +664,18 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
       familyName?: string,
     ): Promise<SdkResponse<UserResponse>> =>
       transformResponse<SingleUserResponse, UserResponse>(
-        sdk.httpClient.post(
-          apiPaths.user.updateDisplayName,
-          { loginId, displayName, givenName, middleName, familyName },
-          { token: managementKey },
-        ),
+        httpClient.post(apiPaths.user.updateDisplayName, {
+          loginId,
+          displayName,
+          givenName,
+          middleName,
+          familyName,
+        }),
         (data) => data.user,
       ),
     updatePicture: (loginId: string, picture: string): Promise<SdkResponse<UserResponse>> =>
       transformResponse<SingleUserResponse, UserResponse>(
-        sdk.httpClient.post(
-          apiPaths.user.updatePicture,
-          { loginId, picture },
-          { token: managementKey },
-        ),
+        httpClient.post(apiPaths.user.updatePicture, { loginId, picture }),
         (data) => data.user,
       ),
     updateCustomAttribute: (
@@ -738,56 +684,36 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
       attributeValue: AttributesTypes,
     ): Promise<SdkResponse<UserResponse>> =>
       transformResponse<SingleUserResponse, UserResponse>(
-        sdk.httpClient.post(
-          apiPaths.user.updateCustomAttribute,
-          { loginId, attributeKey, attributeValue },
-          { token: managementKey },
-        ),
+        httpClient.post(apiPaths.user.updateCustomAttribute, {
+          loginId,
+          attributeKey,
+          attributeValue,
+        }),
         (data) => data.user,
       ),
     setRoles: (loginId: string, roles: string[]): Promise<SdkResponse<UserResponse>> =>
       transformResponse<SingleUserResponse, UserResponse>(
-        sdk.httpClient.post(
-          apiPaths.user.setRole,
-          { loginId, roleNames: roles },
-          { token: managementKey },
-        ),
+        httpClient.post(apiPaths.user.setRole, { loginId, roleNames: roles }),
         (data) => data.user,
       ),
     addRoles: (loginId: string, roles: string[]): Promise<SdkResponse<UserResponse>> =>
       transformResponse<SingleUserResponse, UserResponse>(
-        sdk.httpClient.post(
-          apiPaths.user.addRole,
-          { loginId, roleNames: roles },
-          { token: managementKey },
-        ),
+        httpClient.post(apiPaths.user.addRole, { loginId, roleNames: roles }),
         (data) => data.user,
       ),
     removeRoles: (loginId: string, roles: string[]): Promise<SdkResponse<UserResponse>> =>
       transformResponse<SingleUserResponse, UserResponse>(
-        sdk.httpClient.post(
-          apiPaths.user.removeRole,
-          { loginId, roleNames: roles },
-          { token: managementKey },
-        ),
+        httpClient.post(apiPaths.user.removeRole, { loginId, roleNames: roles }),
         (data) => data.user,
       ),
     addTenant: (loginId: string, tenantId: string): Promise<SdkResponse<UserResponse>> =>
       transformResponse<SingleUserResponse, UserResponse>(
-        sdk.httpClient.post(
-          apiPaths.user.addTenant,
-          { loginId, tenantId },
-          { token: managementKey },
-        ),
+        httpClient.post(apiPaths.user.addTenant, { loginId, tenantId }),
         (data) => data.user,
       ),
     removeTenant: (loginId: string, tenantId: string): Promise<SdkResponse<UserResponse>> =>
       transformResponse<SingleUserResponse, UserResponse>(
-        sdk.httpClient.post(
-          apiPaths.user.removeTenant,
-          { loginId, tenantId },
-          { token: managementKey },
-        ),
+        httpClient.post(apiPaths.user.removeTenant, { loginId, tenantId }),
         (data) => data.user,
       ),
     setTenantRoles: (
@@ -796,11 +722,7 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
       roles: string[],
     ): Promise<SdkResponse<UserResponse>> =>
       transformResponse<SingleUserResponse, UserResponse>(
-        sdk.httpClient.post(
-          apiPaths.user.setRole,
-          { loginId, tenantId, roleNames: roles },
-          { token: managementKey },
-        ),
+        httpClient.post(apiPaths.user.setRole, { loginId, tenantId, roleNames: roles }),
         (data) => data.user,
       ),
     addTenantRoles: (
@@ -809,11 +731,7 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
       roles: string[],
     ): Promise<SdkResponse<UserResponse>> =>
       transformResponse<SingleUserResponse, UserResponse>(
-        sdk.httpClient.post(
-          apiPaths.user.addRole,
-          { loginId, tenantId, roleNames: roles },
-          { token: managementKey },
-        ),
+        httpClient.post(apiPaths.user.addRole, { loginId, tenantId, roleNames: roles }),
         (data) => data.user,
       ),
     removeTenantRoles: (
@@ -822,38 +740,22 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
       roles: string[],
     ): Promise<SdkResponse<UserResponse>> =>
       transformResponse<SingleUserResponse, UserResponse>(
-        sdk.httpClient.post(
-          apiPaths.user.removeRole,
-          { loginId, tenantId, roleNames: roles },
-          { token: managementKey },
-        ),
+        httpClient.post(apiPaths.user.removeRole, { loginId, tenantId, roleNames: roles }),
         (data) => data.user,
       ),
     addSSOapps: (loginId: string, ssoAppIds: string[]): Promise<SdkResponse<UserResponse>> =>
       transformResponse<SingleUserResponse, UserResponse>(
-        sdk.httpClient.post(
-          apiPaths.user.addSSOApps,
-          { loginId, ssoAppIds },
-          { token: managementKey },
-        ),
+        httpClient.post(apiPaths.user.addSSOApps, { loginId, ssoAppIds }),
         (data) => data.user,
       ),
     setSSOapps: (loginId: string, ssoAppIds: string[]): Promise<SdkResponse<UserResponse>> =>
       transformResponse<SingleUserResponse, UserResponse>(
-        sdk.httpClient.post(
-          apiPaths.user.setSSOApps,
-          { loginId, ssoAppIds },
-          { token: managementKey },
-        ),
+        httpClient.post(apiPaths.user.setSSOApps, { loginId, ssoAppIds }),
         (data) => data.user,
       ),
     removeSSOapps: (loginId: string, ssoAppIds: string[]): Promise<SdkResponse<UserResponse>> =>
       transformResponse<SingleUserResponse, UserResponse>(
-        sdk.httpClient.post(
-          apiPaths.user.removeSSOApps,
-          { loginId, ssoAppIds },
-          { token: managementKey },
-        ),
+        httpClient.post(apiPaths.user.removeSSOApps, { loginId, ssoAppIds }),
         (data) => data.user,
       ),
 
@@ -874,11 +776,11 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
       loginOptions?: LoginOptions,
     ): Promise<SdkResponse<GenerateOTPForTestResponse>> =>
       transformResponse<GenerateOTPForTestResponse>(
-        sdk.httpClient.post(
-          apiPaths.user.generateOTPForTest,
-          { deliveryMethod, loginId, loginOptions },
-          { token: managementKey },
-        ),
+        httpClient.post(apiPaths.user.generateOTPForTest, {
+          deliveryMethod,
+          loginId,
+          loginOptions,
+        }),
         (data) => data,
       ),
 
@@ -901,11 +803,12 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
       loginOptions?: LoginOptions,
     ): Promise<SdkResponse<GenerateMagicLinkForTestResponse>> =>
       transformResponse<GenerateMagicLinkForTestResponse>(
-        sdk.httpClient.post(
-          apiPaths.user.generateMagicLinkForTest,
-          { deliveryMethod, loginId, URI: uri, loginOptions },
-          { token: managementKey },
-        ),
+        httpClient.post(apiPaths.user.generateMagicLinkForTest, {
+          deliveryMethod,
+          loginId,
+          URI: uri,
+          loginOptions,
+        }),
         (data) => data,
       ),
 
@@ -926,11 +829,11 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
       loginOptions?: LoginOptions,
     ): Promise<SdkResponse<GenerateEnchantedLinkForTestResponse>> =>
       transformResponse<GenerateEnchantedLinkForTestResponse>(
-        sdk.httpClient.post(
-          apiPaths.user.generateEnchantedLinkForTest,
-          { loginId, URI: uri, loginOptions },
-          { token: managementKey },
-        ),
+        httpClient.post(apiPaths.user.generateEnchantedLinkForTest, {
+          loginId,
+          URI: uri,
+          loginOptions,
+        }),
         (data) => data,
       ),
 
@@ -940,11 +843,7 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
       timeout?: number,
     ): Promise<SdkResponse<GenerateEmbeddedLinkResponse>> =>
       transformResponse<GenerateEmbeddedLinkResponse>(
-        sdk.httpClient.post(
-          apiPaths.user.generateEmbeddedLink,
-          { loginId, customClaims, timeout },
-          { token: managementKey },
-        ),
+        httpClient.post(apiPaths.user.generateEmbeddedLink, { loginId, customClaims, timeout }),
         (data) => data,
       ),
 
@@ -964,11 +863,14 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
       timeout?: number,
     ): Promise<SdkResponse<GenerateEmbeddedLinkResponse>> =>
       transformResponse<GenerateEmbeddedLinkResponse>(
-        sdk.httpClient.post(
-          apiPaths.user.generateSignUpEmbeddedLink,
-          { loginId, user, emailVerified, phoneVerified, loginOptions, timeout },
-          { token: managementKey },
-        ),
+        httpClient.post(apiPaths.user.generateSignUpEmbeddedLink, {
+          loginId,
+          user,
+          emailVerified,
+          phoneVerified,
+          loginOptions,
+          timeout,
+        }),
         (data) => data,
       ),
 
@@ -982,11 +884,7 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
      */
     setTemporaryPassword: (loginId: string, password: string): Promise<SdkResponse<never>> =>
       transformResponse<never>(
-        sdk.httpClient.post(
-          apiPaths.user.setTemporaryPassword,
-          { loginId, password },
-          { token: managementKey },
-        ),
+        httpClient.post(apiPaths.user.setTemporaryPassword, { loginId, password }),
         (data) => data,
       ),
 
@@ -997,11 +895,7 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
      */
     setActivePassword: (loginId: string, password: string): Promise<SdkResponse<never>> =>
       transformResponse<never>(
-        sdk.httpClient.post(
-          apiPaths.user.setActivePassword,
-          { loginId, password },
-          { token: managementKey },
-        ),
+        httpClient.post(apiPaths.user.setActivePassword, { loginId, password }),
         (data) => data,
       ),
 
@@ -1015,11 +909,7 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
      */
     setPassword: (loginId: string, password: string): Promise<SdkResponse<never>> =>
       transformResponse<never>(
-        sdk.httpClient.post(
-          apiPaths.user.setPassword,
-          { loginId, password },
-          { token: managementKey },
-        ),
+        httpClient.post(apiPaths.user.setPassword, { loginId, password }),
         (data) => data,
       ),
 
@@ -1031,7 +921,7 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
      */
     expirePassword: (loginId: string): Promise<SdkResponse<never>> =>
       transformResponse<never>(
-        sdk.httpClient.post(apiPaths.user.expirePassword, { loginId }, { token: managementKey }),
+        httpClient.post(apiPaths.user.expirePassword, { loginId }),
         (data) => data,
       ),
 
@@ -1043,7 +933,7 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
      */
     removeAllPasskeys: (loginId: string): Promise<SdkResponse<never>> =>
       transformResponse<never>(
-        sdk.httpClient.post(apiPaths.user.removeAllPasskeys, { loginId }, { token: managementKey }),
+        httpClient.post(apiPaths.user.removeAllPasskeys, { loginId }),
         (data) => data,
       ),
 
@@ -1055,7 +945,7 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
      */
     removeTOTPSeed: (loginId: string): Promise<SdkResponse<never>> =>
       transformResponse<never>(
-        sdk.httpClient.post(apiPaths.user.removeTOTPSeed, { loginId }, { token: managementKey }),
+        httpClient.post(apiPaths.user.removeTOTPSeed, { loginId }),
         (data) => data,
       ),
 
@@ -1065,7 +955,7 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
      */
     history: (userIds: string[]): Promise<SdkResponse<UserHistoryResponse[]>> =>
       transformResponse<UserHistoryResponse[]>(
-        sdk.httpClient.post(apiPaths.user.history, userIds, { token: managementKey }),
+        httpClient.post(apiPaths.user.history, userIds),
         (data) => data,
       ),
   };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -24,5 +24,4 @@ export interface RefreshAuthenticationInfo extends AuthenticationInfo {
 /** Descope core SDK type */
 export type CreateCoreSdk = typeof createSdk;
 export type CoreSdkConfig = Head<Parameters<CreateCoreSdk>>;
-export type CoreSdk = ReturnType<CreateCoreSdk>;
 export type DeliveryMethodForTestUser = DeliveryMethod | 'Embedded';

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.7.12",
       "license": "MIT",
       "dependencies": {
-        "@descope/core-js-sdk": "2.46.0",
+        "@descope/core-js-sdk": "2.46.1",
         "cross-fetch": "^4.0.0",
         "jose": "5.2.2",
         "tslib": "^2.0.0"
@@ -607,9 +607,9 @@
       }
     },
     "node_modules/@descope/core-js-sdk": {
-      "version": "2.46.0",
-      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.46.0.tgz",
-      "integrity": "sha512-9anRZtWptTD2O8d4s0KpSHiGvfu0f9iSauacR2Mpn2MUvfHQtLfE2ckl4uDBCmF+INvxA94ryOTaqw7HYZl45Q==",
+      "version": "2.46.1",
+      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.46.1.tgz",
+      "integrity": "sha512-ptUAI7UPn7dfoMab6gFWC6VZQQp8/NTydFyr8MAZIIHW4n+8sGUkRHitXwyeNoNKhF7dwqncT54cwOD6q0pUmQ==",
       "license": "MIT",
       "dependencies": {
         "jwt-decode": "4.0.0"

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "typescript": "^4.6.4"
   },
   "dependencies": {
-    "@descope/core-js-sdk": "2.46.0",
+    "@descope/core-js-sdk": "2.46.1",
     "cross-fetch": "^4.0.0",
     "jose": "5.2.2",
     "tslib": "^2.0.0"


### PR DESCRIPTION
## Related Issues

https://github.com/descope/etc/issues/8683

## Description

Relies on: https://github.com/descope/descope-js/pull/1186
Use separate http clients for auth and management to ensure the correct management key is appended to the authorization header.

## Must

- [x] Tests
- [ ] Documentation (if applicable)
