### PR TITLE
Add support for "Batch Delete Users"

### DIFF
--- a/README.md
+++ b/README.md
@@ -827,6 +827,8 @@ await descopeClient.management.user.patch('desmond@descope.com', options);
 
 // User deletion cannot be undone. Use carefully.
 await descopeClient.management.user.delete('desmond@descope.com');
+// Delete a batch of users. This requires Descope user IDs.
+await descopeClient.management.user.deleteBatch(['<user-ID-1>', '<user-ID-2>']);
 
 // Load specific user
 const userRes = await descopeClient.management.user.load('desmond@descope.com');

--- a/lib/management/paths.ts
+++ b/lib/management/paths.ts
@@ -7,6 +7,7 @@ export default {
     update: '/v1/mgmt/user/update',
     patch: '/v1/mgmt/user/patch',
     delete: '/v1/mgmt/user/delete',
+    deleteBatch: '/v1/mgmt/user/delete/batch',
     deleteAllTestUsers: '/v1/mgmt/user/test/delete/all',
     load: '/v1/mgmt/user',
     logout: '/v1/mgmt/user/logout',

--- a/lib/management/user.test.ts
+++ b/lib/management/user.test.ts
@@ -666,6 +666,35 @@ describe('Management User', () => {
     });
   });
 
+  describe('deleteBatch', () => {
+    it('should send the correct request and receive correct response', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => {},
+        clone: () => ({
+          json: () => Promise.resolve({}),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const resp: SdkResponse<UserResponse> = await management.user.deleteBatch(['a', 'b']);
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        apiPaths.user.deleteBatch,
+        { userIds: ['a', 'b'] },
+        { token: 'key' },
+      );
+
+      expect(resp).toEqual({
+        code: 200,
+        data: {},
+        ok: true,
+        response: httpResponse,
+      });
+    });
+  });
+
   describe('deleteByUserId', () => {
     it('should send the correct request and receive correct response', async () => {
       const httpResponse = {

--- a/lib/management/user.ts
+++ b/lib/management/user.ts
@@ -485,6 +485,10 @@ const withUser = (sdk: CoreSdk, managementKey?: string) => {
         ),
         (data) => data,
       ),
+    deleteBatch: (userIds: string[]): Promise<SdkResponse<never>> =>
+      transformResponse(
+        sdk.httpClient.post(apiPaths.user.deleteBatch, { userIds }, { token: managementKey }),
+      ),
     update,
     patch,
     /**


### PR DESCRIPTION
Fixes descope/etc#11608

## Description

Add this endpoint to bring node-sdk closer to parity with the API: https://docs.descope.com/api/management/users/batch-delete-users

## Must

- [X] Tests
- [X] Documentation (if applicable)
