### PR TITLE
Support session migration

### DIFF
--- a/lib/index.test.ts
+++ b/lib/index.test.ts
@@ -251,6 +251,31 @@ describe('sdk', () => {
     });
   });
 
+  describe('refresh', () => {
+    it('should call coreSdk.refresh with the correct arguments', async () => {
+      jest.resetModules();
+      const refresh = jest.fn();
+      jest.doMock('@descope/core-js-sdk', () => {
+        const actual = jest.requireActual('@descope/core-js-sdk');
+        return {
+          ...actual,
+          __esModule: true,
+          wrapWith: (sdkInstance: object) => sdkInstance,
+          default: (...args: any[]) => ({ ...actual.default(...args), refresh }),
+        };
+      });
+
+      const createNodeSdk = require('.').default; // eslint-disable-line
+      const sdkInstance = createNodeSdk({ projectId: 'project-id' });
+
+      const token = 'test-token';
+      const externalToken = 'external-token';
+      await sdkInstance.refresh(token, externalToken);
+
+      expect(refresh).toHaveBeenCalledWith(token, undefined, externalToken);
+    });
+  });
+
   describe('validateAndRefreshSession', () => {
     it('should throw an error when both session or refresh tokens are empty', async () => {
       await expect(sdk.validateAndRefreshSession('', '')).rejects.toThrow(

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -134,7 +134,8 @@ const nodeSdk = ({ authManagementKey, managementKey, publicKey, ...config }: Nod
     ...coreSdk,
 
     // Overrides core-sdk refresh, because the core-sdk exposes queryParams, which is for internal use only
-    refresh: async (token?: string) => coreSdk.refresh(token),
+    refresh: async (token?: string, externalToken?: string) =>
+      coreSdk.refresh(token, undefined, externalToken),
 
     /**
      * Provides various APIs for managing a Descope project programmatically. A management key must
@@ -201,7 +202,9 @@ const nodeSdk = ({ authManagementKey, managementKey, publicKey, ...config }: Nod
     },
 
     /**
-     * Refresh the session using a refresh token
+     * Refresh the session using a refresh token.
+     * For session migration, use {@link sdk.refresh}.
+     *
      * @param refreshToken refresh JWT to refresh the session with
      * @returns RefreshAuthenticationInfo promise or throws Error if there is an issue with JWTs
      */


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/11907

Passes through the `externalToken` argument and adds a test for the small override that removes the private argument from descope-js.

## Must

- [X] Tests
- [X] Documentation (if applicable)
