### PR TITLE
Add audience claim enforcement in session validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,24 +442,26 @@ const refreshed = await descopeClient.refreshSession('refreshToken');
 // have the session validated and automatically refreshed when expired
 const combined = await descopeClient.validateAndRefreshSession('sessionToken', 'refreshToken');
 
-// Optional: Validate audience (aud) for backend-only flows
+// Optional: Validate audience  for backend-only flows
 // Provide VerifyOptions with the expected audience(s)
-const withAud = await descopeClient.validateSession('sessionToken', { aud: 'my-audience' });
-const withAudArray = await descopeClient.validateSession('sessionToken', { aud: ['a', 'b'] });
+const withAud = await descopeClient.validateSession('sessionToken', { audience: 'my-audience' });
+const withAudArray = await descopeClient.validateSession('sessionToken', { audience: ['a', 'b'] });
 
 // Audience is enforced for session JWTs only (including after refresh)
-const refreshedWithAud = await descopeClient.refreshSession('refreshToken', { aud: 'api' });
+const refreshedWithAud = await descopeClient.refreshSession('refreshToken', { audience: 'api' });
 const combinedWithAud = await descopeClient.validateAndRefreshSession(
   'sessionToken',
   'refreshToken',
-  { aud: 'api' },
+  { audience: 'api' },
 );
 ```
 
 For access keys, you can also validate the returned session against an audience:
 
 ```typescript
-const authInfo = await descopeClient.exchangeAccessKey('access_key', undefined, { aud: 'api' });
+const authInfo = await descopeClient.exchangeAccessKey('access_key', undefined, {
+  audience: 'api',
+});
 ```
 
 Choose the right session validation and refresh combination that suits your needs.

--- a/lib/index.test.ts
+++ b/lib/index.test.ts
@@ -151,12 +151,12 @@ describe('sdk', () => {
     it('should reject when audience is required but missing in token', async () => {
       // Calling with an audience should enforce aud claim; current implementation ignores it.
       await expect(
-        (sdk as any).validateSession(validToken, { aud: 'expected-aud' }),
+        (sdk as any).validateSession(validToken, { audience: 'expected-aud' }),
       ).rejects.toThrow('session validation failed');
     });
 
     it('should reject when audience mismatches in token for validateSession', async () => {
-      await expect((sdk as any).validateSession(tokenAudA, { aud: 'aud-b' })).rejects.toThrow(
+      await expect((sdk as any).validateSession(tokenAudA, { audience: 'aud-b' })).rejects.toThrow(
         'session validation failed',
       );
     });
@@ -164,12 +164,12 @@ describe('sdk', () => {
     it('should accept when audience matches in token for validateSession', async () => {
       // This may pass before implementation but documents expected behavior post-change
       await expect(
-        (sdk as any).validateSession(tokenAudA, { aud: 'aud-a' }),
+        (sdk as any).validateSession(tokenAudA, { audience: 'aud-a' }),
       ).resolves.toHaveProperty('jwt', tokenAudA);
     });
 
     it('should reject when audience mismatches in validateJwt', async () => {
-      await expect((sdk as any).validateJwt(tokenAudB, { aud: 'aud-a' })).rejects.toBeTruthy();
+      await expect((sdk as any).validateJwt(tokenAudB, { audience: 'aud-a' })).rejects.toBeTruthy();
     });
 
     it('should reject when refreshSession returns session with mismatched audience', async () => {
@@ -178,7 +178,7 @@ describe('sdk', () => {
         data: { sessionJwt: tokenAudB },
       } as SdkResponse<JWTResponse>);
 
-      await expect((sdk as any).refreshSession(validToken, { aud: 'aud-a' })).rejects.toThrow(
+      await expect((sdk as any).refreshSession(validToken, { audience: 'aud-a' })).rejects.toThrow(
         'refresh token validation failed',
       );
       expect(spyRefresh).toHaveBeenCalledWith(validToken);
@@ -191,14 +191,14 @@ describe('sdk', () => {
       } as SdkResponse<JWTResponse>);
 
       await expect(
-        (sdk as any).validateAndRefreshSession(expiredTokenAudA, validToken, { aud: 'aud-a' }),
+        (sdk as any).validateAndRefreshSession(expiredTokenAudA, validToken, { audience: 'aud-a' }),
       ).rejects.toThrow('refresh token validation failed');
       expect(spyRefresh).toHaveBeenCalledWith(validToken);
     });
 
     it('should accept when any of audiences matches (array)', async () => {
       await expect(
-        (sdk as any).validateSession(tokenAudA, { aud: ['nope', 'aud-a'] }),
+        (sdk as any).validateSession(tokenAudA, { audience: ['nope', 'aud-a'] }),
       ).resolves.toHaveProperty('jwt', tokenAudA);
     });
   });
@@ -473,7 +473,7 @@ describe('sdk', () => {
         data: { sessionJwt: tokenAudA },
       } as SdkResponse<ExchangeAccessKeyResponse>);
       await expect(
-        sdk.exchangeAccessKey('key', undefined, { aud: 'aud-a' }),
+        sdk.exchangeAccessKey('key', undefined, { audience: 'aud-a' }),
       ).resolves.toHaveProperty('jwt', tokenAudA);
       expect(spyExchange).toHaveBeenCalledWith('key', undefined);
     });
@@ -483,7 +483,7 @@ describe('sdk', () => {
         ok: true,
         data: { sessionJwt: tokenAudB },
       } as SdkResponse<ExchangeAccessKeyResponse>);
-      await expect(sdk.exchangeAccessKey('key', undefined, { aud: 'aud-a' })).rejects.toThrow(
+      await expect(sdk.exchangeAccessKey('key', undefined, { audience: 'aud-a' })).rejects.toThrow(
         'could not exchange access key - failed to validate jwt',
       );
       expect(spyExchange).toHaveBeenCalledWith('key', undefined);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -161,13 +161,13 @@ const nodeSdk = ({ authManagementKey, managementKey, publicKey, ...config }: Nod
     /**
      * Validate the given JWT with the right key and make sure the issuer is correct
      * @param jwt the JWT string to parse and validate
-     * @param options optional verification options (e.g., { aud })
+     * @param options optional verification options (e.g., { audience })
      * @returns AuthenticationInfo with the parsed token and JWT. Will throw an error if validation fails.
      */
     async validateJwt(jwt: string, options?: VerifyOptions): Promise<AuthenticationInfo> {
       // Do not hard-code the algo because library does not support `None` so all are valid
       const verifyOptions: Record<string, unknown> = { clockTolerance: 5 };
-      if (options?.aud) verifyOptions.audience = options.aud;
+      if (options?.audience) verifyOptions.audience = options.audience;
       const res = await jwtVerify(jwt, sdk.getKey, verifyOptions);
       const token = res.payload;
 
@@ -189,7 +189,7 @@ const nodeSdk = ({ authManagementKey, managementKey, publicKey, ...config }: Nod
     /**
      * Validate an active session
      * @param sessionToken session JWT to validate
-     * @param options optional verification options (e.g., { aud })
+     * @param options optional verification options (e.g., { audience })
      * @returns AuthenticationInfo promise or throws Error if there is an issue with JWTs
      */
     async validateSession(
@@ -213,7 +213,7 @@ const nodeSdk = ({ authManagementKey, managementKey, publicKey, ...config }: Nod
      * For session migration, use {@link sdk.refresh}.
      *
      * @param refreshToken refresh JWT to refresh the session with
-     * @param options optional verification options for the new session (e.g., { aud })
+     * @param options optional verification options for the new session (e.g., { audience })
      * @returns RefreshAuthenticationInfo promise or throws Error if there is an issue with JWTs
      */
     async refreshSession(
@@ -254,7 +254,7 @@ const nodeSdk = ({ authManagementKey, managementKey, publicKey, ...config }: Nod
      * Validate session and refresh it if it expired
      * @param sessionToken session JWT
      * @param refreshToken refresh JWT
-     * @param options optional verification options (e.g., { aud }) used on validation and post-refresh
+     * @param options optional verification options (e.g., { audience }) used on validation and post-refresh
      * @returns RefreshAuthenticationInfo promise or throws Error if there is an issue with JWTs
      */
     async validateAndRefreshSession(
@@ -279,7 +279,7 @@ const nodeSdk = ({ authManagementKey, managementKey, publicKey, ...config }: Nod
      * Exchange API key (access key) for a session key
      * @param accessKey access key to exchange for a session JWT
      * @param loginOptions Optional advanced controls over login parameters
-     * @param options optional verification options for the returned session (e.g., { aud })
+     * @param options optional verification options for the returned session (e.g., { audience })
      * @returns AuthenticationInfo with session JWT data
      */
     async exchangeAccessKey(

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -23,7 +23,7 @@ export interface RefreshAuthenticationInfo extends AuthenticationInfo {
 
 /** Options for token verification (extensible). For now only audience. */
 export interface VerifyOptions {
-  aud?: string | string[];
+  audience?: string | string[];
 }
 
 /** Descope core SDK type */


### PR DESCRIPTION
## Related Issues

Related https://github.com/descope/etc/issues/11501

## Description

Introduce optional audience validation in session and JWT flows, enhancing security by enforcing audience claims during validation and refresh processes. 

## Must

- [x] Tests
- [x] Documentation (if applicable)


