### PR TITLE
Added scopes to AuthenticationInfo interface

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -8,3 +8,5 @@ export const authorizedTenantsClaimName = 'tenants';
 export const permissionsClaimName = 'permissions';
 /** The key of the roles claims in the claims map either under tenant or top level */
 export const rolesClaimName = 'roles';
+/** The key of the scopes claims in the claims map */
+export const scopesClaimName = 'scopes';

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -1,5 +1,5 @@
 import type { SdkFnWrapper } from '@descope/core-js-sdk';
-import { authorizedTenantsClaimName, refreshTokenCookieName } from './constants';
+import { authorizedTenantsClaimName, refreshTokenCookieName, scopesClaimName } from './constants';
 import { AuthenticationInfo } from './types';
 
 /**
@@ -85,4 +85,36 @@ export function getAuthorizationClaimItems(
  */
 export function isUserAssociatedWithTenant(authInfo: AuthenticationInfo, tenant: string): boolean {
   return !!authInfo.token[authorizedTenantsClaimName]?.[tenant];
+}
+
+/**
+ * Get the scopes from the JWT token
+ * @param authInfo The parsed authentication info from the JWT
+ * @returns the scopes from the top-level claim
+ */
+export function getScopes(authInfo: AuthenticationInfo): string[] {
+  const value = authInfo.token[scopesClaimName];
+  return Array.isArray(value) ? value : [];
+}
+
+/**
+ * Check if the user has all the required scopes
+ * @param authInfo The parsed authentication info from the JWT
+ * @param scopes list of scopes to check for
+ * @returns true if user has all required scopes, false otherwise
+ */
+export function hasScopes(authInfo: AuthenticationInfo, scopes: string[]): boolean {
+  const userScopes = getScopes(authInfo);
+  return scopes.every((scope) => userScopes.includes(scope));
+}
+
+/**
+ * Get the scopes that match the required scopes
+ * @param authInfo The parsed authentication info from the JWT
+ * @param scopes list of scopes to match against
+ * @returns array of scopes that match the required scopes
+ */
+export function getMatchedScopes(authInfo: AuthenticationInfo, scopes: string[]): string[] {
+  const userScopes = getScopes(authInfo);
+  return scopes.filter((scope) => userScopes.includes(scope));
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -7,6 +7,7 @@ interface Token {
   sub?: string;
   exp?: number;
   iss?: string;
+  scopes?: string[];
   [claim: string]: unknown;
 }
 
@@ -19,6 +20,11 @@ export interface AuthenticationInfo {
 
 export interface RefreshAuthenticationInfo extends AuthenticationInfo {
   refreshJwt?: string;
+}
+
+/** Options for token verification (extensible). For now only audience. */
+export interface VerifyOptions {
+  audience?: string | string[];
 }
 
 /** Descope core SDK type */


### PR DESCRIPTION
## Related Issues

Fixes <link_to_github_issue>

## Description

Added `scopes` to the main AuthenticationInfo interface, so it's easier to check and get scopes in the token. 

You can use `claims` but I think we should have a dedicated variable here. Will only apply to OIDC-compliant tokens that include scope claims.

## Must

- [ ] Tests
- [ ] Documentation (if applicable)
