### PR TITLE
fix(husky): quote parameter in commit-msg hook to support inline commits

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-npx --no -- commitlint --edit ${1}
+npx --no -- commitlint --edit "$1"


### PR DESCRIPTION
Fixes descope/node-sdk#639

[View workflow run](https://github.com/descope/shuni/actions/runs/20709257092)

Perfect! Everything is clean now. Let me provide a summary of the fix:

## Summary

I successfully fixed the commit hook failure issue when using `git commit -m` with inline messages.

### The Problem
When Shuni's `action/lib/git.ts` runs `git commit -m "${message}"`, it triggers the husky `commit-msg` hook in the node-sdk repository. The hook was calling:
```bash
npx --no -- commitlint --edit ${1}
```

The unquoted `${1}` parameter could cause issues with:
- File paths containing spaces or special characters
- Proper shell word splitting

### The Solution
Updated `.husky/commit-msg` to properly quote the parameter:
```bash
npx --no -- commitlint --edit "$1"
```

This ensures that:
1. **Inline commits work** (`git commit -m "message"`) - Git creates a temporary file with the message and passes its path as `$1`
2. **Interactive commits work** (`git commit` without `-m`) - Git uses `.git/COMMIT_EDITMSG` and passes its path as `$1`
3. **Validation works** - Invalid commit messages are still properly rejected
4. **Special characters are handled** - File paths with spaces or other characters are properly quoted

### Testing
The fix was tested and verified:
- ✅ Valid inline commit message passes: `git commit -m "fix: support git commit -m with commitlint hook"`
- ✅ Invalid commit message is rejected: `git commit -m "invalid commit message"`
- ✅ Commit was successfully created with the correct message format

The change is minimal (adding quotes around `$1`) but critical for supporting both interactive and inline commit modes.

---
*Created by [Shuni](https://github.com/descope/shuni) 🐕*