### PR TITLE
feat(sso-app): add default signature method

### DIFF
--- a/lib/management/ssoapplication.test.ts
+++ b/lib/management/ssoapplication.test.ts
@@ -274,6 +274,7 @@ describe('Management SSOApplication', () => {
         enabled: true,
         useMetadataInfo: false,
         entityId: 'ent1234',
+        defaultSignatureAlgorithm: 'sha256',
       });
 
       expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.ssoApplication.samlUpdate, {
@@ -296,6 +297,7 @@ describe('Management SSOApplication', () => {
         defaultRelayState: undefined,
         forceAuthentication: undefined,
         logoutRedirectUrl: undefined,
+        defaultSignatureAlgorithm: 'sha256',
       });
 
       expect(resp).toEqual({

--- a/lib/management/types.ts
+++ b/lib/management/types.ts
@@ -240,7 +240,7 @@ export type SSOApplicationSAMLSettings = {
   /** The signature algorithm used to sign SAML responses. Only applies to IdP-initiated flows —
    * SP-initiated flows use the algorithm from the SP's SAML request.
    * "sha256" means SHA-256; empty string means the default (SHA-1). */
-  defaultSignatureAlgorithm: string;
+  defaultSignatureAlgorithm?: string;
 };
 
 /** Represents an SSO application in a project. */


### PR DESCRIPTION
## Related Issues

https://github.com/descope/etc/issues/14607

## Description

feat(sso-app): add default signature method

## Must

- [x] Tests
- [x] Documentation (if applicable)
