### PR TITLE
feat(user): return created flag in CreateUser response

### DIFF
--- a/lib/management/types.ts
+++ b/lib/management/types.ts
@@ -17,6 +17,12 @@ export type CreateTenantResponse = {
   id: string;
 };
 
+/** Response from creating a single user, includes the user details and whether the user was newly created */
+export type CreateUserResponse = {
+  user: UserResponse;
+  created: boolean;
+};
+
 export type GenerateSSOConfigurationLinkResponse = {
   adminSSOConfigurationLink: string;
 };

--- a/lib/management/user.ts
+++ b/lib/management/user.ts
@@ -22,6 +22,7 @@ import {
   ProviderTokenOptions,
   UserOptions,
   UserSearchResponse,
+  CreateUserResponse,
 } from './types';
 import { DeliveryMethodForTestUser } from '../types';
 import apiPaths from './paths';
@@ -63,6 +64,7 @@ type SearchRequest = {
 
 type SingleUserResponse = {
   user: UserResponse;
+  created?: boolean;
 };
 
 type MultipleUsersResponse = {
@@ -71,7 +73,7 @@ type MultipleUsersResponse = {
 
 const withUser = (httpClient: HttpClient) => {
   /* Create User */
-  function create(loginId: string, options?: UserOptions): Promise<SdkResponse<UserResponse>>;
+  function create(loginId: string, options?: UserOptions): Promise<SdkResponse<CreateUserResponse>>;
   function create(
     loginId: string,
     email?: string,
@@ -87,7 +89,7 @@ const withUser = (httpClient: HttpClient) => {
     middleName?: string,
     familyName?: string,
     additionalLoginIds?: string[],
-  ): Promise<SdkResponse<UserResponse>>;
+  ): Promise<SdkResponse<CreateUserResponse>>;
 
   function create(
     loginId: string,
@@ -104,7 +106,7 @@ const withUser = (httpClient: HttpClient) => {
     middleName?: string,
     familyName?: string,
     additionalLoginIds?: string[],
-  ): Promise<SdkResponse<UserResponse>> {
+  ): Promise<SdkResponse<CreateUserResponse>> {
     // We support both the old and new parameters forms of create user
     // 1. The new form - create(loginId, { email, phone, ... }})
     // 2. The old form - create(loginId, email, phone, ...)
@@ -132,9 +134,9 @@ const withUser = (httpClient: HttpClient) => {
             roleNames: emailOrOptions?.roles,
             roles: undefined,
           };
-    return transformResponse<SingleUserResponse, UserResponse>(
+    return transformResponse<SingleUserResponse, CreateUserResponse>(
       httpClient.post(apiPaths.user.create, body),
-      (data) => data.user,
+      (data) => ({ user: data.user, created: data.created ?? false }),
     );
   }
   /* Create User End */
@@ -143,7 +145,7 @@ const withUser = (httpClient: HttpClient) => {
   function createTestUser(
     loginId: string,
     options?: UserOptions,
-  ): Promise<SdkResponse<UserResponse>>;
+  ): Promise<SdkResponse<CreateUserResponse>>;
   function createTestUser(
     loginId: string,
     email?: string,
@@ -159,7 +161,7 @@ const withUser = (httpClient: HttpClient) => {
     middleName?: string,
     familyName?: string,
     additionalLoginIds?: string[],
-  ): Promise<SdkResponse<UserResponse>>;
+  ): Promise<SdkResponse<CreateUserResponse>>;
 
   function createTestUser(
     loginId: string,
@@ -176,7 +178,7 @@ const withUser = (httpClient: HttpClient) => {
     middleName?: string,
     familyName?: string,
     additionalLoginIds?: string[],
-  ): Promise<SdkResponse<UserResponse>> {
+  ): Promise<SdkResponse<CreateUserResponse>> {
     // We support both the old and new parameters forms of create test user
     // 1. The new form - createTestUser(loginId, { email, phone, ... }})
     // 2. The old form - createTestUser(loginId, email, phone, ...)
@@ -206,9 +208,9 @@ const withUser = (httpClient: HttpClient) => {
             roles: undefined,
             test: true,
           };
-    return transformResponse<SingleUserResponse, UserResponse>(
+    return transformResponse<SingleUserResponse, CreateUserResponse>(
       httpClient.post(apiPaths.user.createTestUser, body),
-      (data) => data.user,
+      (data) => ({ user: data.user, created: data.created ?? false }),
     );
   }
   /* Create Test User End */
@@ -223,7 +225,7 @@ const withUser = (httpClient: HttpClient) => {
       templateOptions?: TemplateOptions;
       templateId?: string;
     },
-  ): Promise<SdkResponse<UserResponse>>;
+  ): Promise<SdkResponse<CreateUserResponse>>;
   function invite(
     loginId: string,
     email?: string,
@@ -243,7 +245,7 @@ const withUser = (httpClient: HttpClient) => {
     familyName?: string,
     additionalLoginIds?: string[],
     templateId?: string,
-  ): Promise<SdkResponse<UserResponse>>;
+  ): Promise<SdkResponse<CreateUserResponse>>;
 
   function invite(
     loginId: string,
@@ -264,7 +266,7 @@ const withUser = (httpClient: HttpClient) => {
     familyName?: string,
     additionalLoginIds?: string[],
     templateId?: string,
-  ): Promise<SdkResponse<UserResponse>> {
+  ): Promise<SdkResponse<CreateUserResponse>> {
     // We support both the old and new parameters forms of invite user
     // 1. The new form - invite(loginId, { email, phone, ... }})
     // 2. The old form - invite(loginId, email, phone, ...)
@@ -298,9 +300,9 @@ const withUser = (httpClient: HttpClient) => {
             roles: undefined,
             invite: true,
           };
-    return transformResponse<SingleUserResponse, UserResponse>(
+    return transformResponse<SingleUserResponse, CreateUserResponse>(
       httpClient.post(apiPaths.user.create, body),
-      (data) => data.user,
+      (data) => ({ user: data.user, created: data.created ?? false }),
     );
   }
   /* Invite User End */


### PR DESCRIPTION
## Summary
- Add `CreateUserResponse` type `{ user: UserResponse; created: boolean }` to `types.ts`
- Update `create`, `createTestUser`, and `invite` functions to return `Promise<SdkResponse<CreateUserResponse>>`
- Callers can now check `response.data.created` to distinguish a newly created user from a re-invited existing user

## Test plan
- [ ] Verify `create` returns `created: true` for new users
- [ ] Verify `create` (re-invite) returns `created: false` for existing users
- [ ] TypeScript types compile cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)