### PR TITLE
feat(user): add verifiedEmail and verifiedPhone filters to user search

### DIFF
--- a/README.md
+++ b/README.md
@@ -867,7 +867,12 @@ usersRes.data.forEach((user) => {
 
 // Search all users, optionally according to tenant and/or role filter
 // Results can be paginated using the limit and page parameters
-const usersRes = await descopeClient.management.user.search({ tenantIds: ['tenant-ID'] });
+// Additional filters: verifiedEmail, verifiedPhone, statuses, roles, tenantIds, etc.
+const usersRes = await descopeClient.management.user.search({
+  tenantIds: ['tenant-ID'],
+  verifiedEmail: true, // optional: filter by verified email status
+  verifiedPhone: false, // optional: filter by verified phone status
+});
 console.log('Total users:', usersRes.data.total);
 usersRes.data.users.forEach((user) => {
   // do something

--- a/lib/management/user.test.ts
+++ b/lib/management/user.test.ts
@@ -1134,6 +1134,29 @@ describe('Management User', () => {
         response: httpResponse,
       });
     });
+
+    it('should pass verifiedEmail and verifiedPhone filters', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => mockMgmtUsersResponse,
+        clone: () => ({
+          json: () => Promise.resolve(mockMgmtUsersResponse),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+      await management.user.search({
+        verifiedEmail: true,
+        verifiedPhone: false,
+      });
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.search, {
+        verifiedEmail: true,
+        verifiedPhone: false,
+        roleNames: undefined,
+        roles: undefined,
+      });
+    });
   });
 
   describe('getProviderToken', () => {

--- a/lib/management/user.ts
+++ b/lib/management/user.ts
@@ -59,6 +59,8 @@ type SearchRequest = {
   toModifiedTime?: number; // Search users modified before this time (epoch in milliseconds)
   tenantRoleIds?: Record<string, RolesList>; // Search users based on tenants and role IDs
   tenantRoleNames?: Record<string, RolesList>; // Search users based on tenants and role names
+  verifiedEmail?: boolean; // Filter by verified email status
+  verifiedPhone?: boolean; // Filter by verified phone status
 };
 
 type SingleUserResponse = {


### PR DESCRIPTION
## Summary
- Adds `verifiedEmail` and `verifiedPhone` boolean filter fields to the `SearchRequest` type in user management
- Updates README to show the new filter options in the user search example

## Test plan
- [x] Unit tests added for both `verifiedEmail: true` and `verifiedPhone: false` filter scenarios
- [x] Verify the new fields are passed through correctly to the API

🤖 Generated with [Claude Code](https://claude.com/claude-code)