### PR TITLE
feat(tenant): add updateDefaultRoles method

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,6 +630,10 @@ await descopeClient.management.tenant.update(
   { customAttributeName: 'val' },
 );
 
+// Update the tenant's default roles by providing role names.
+// These are project-level roles that will be automatically assigned to users in this tenant.
+await descopeClient.management.tenant.updateDefaultRoles('my-custom-id', ['role1', 'role2']);
+
 // Tenant deletion cannot be undone. Use carefully.
 // Pass true to cascade value, in case you want to delete all users/keys associated only with this tenant
 await descopeClient.management.tenant.delete('my-custom-id', false);

--- a/lib/management/paths.ts
+++ b/lib/management/paths.ts
@@ -70,6 +70,7 @@ export default {
     settings: '/v1/mgmt/tenant/settings',
     loadAll: '/v1/mgmt/tenant/all',
     searchAll: '/v1/mgmt/tenant/search',
+    updateDefaultRoles: '/v1/mgmt/tenant/updateDefaultRoles',
     generateSSOConfigurationLink: '/v2/mgmt/tenant/adminlinks/sso/generate',
   },
   ssoApplication: {

--- a/lib/management/tenant.test.ts
+++ b/lib/management/tenant.test.ts
@@ -248,6 +248,60 @@ describe('Management Tenant', () => {
     });
   });
 
+  describe('updateDefaultRoles', () => {
+    it('should send the correct request and receive correct response', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => {},
+        clone: () => ({
+          json: () => Promise.resolve({}),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const resp = await management.tenant.updateDefaultRoles('t1', ['role1', 'role2']);
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.tenant.updateDefaultRoles, {
+        id: 't1',
+        defaultRoles: ['role1', 'role2'],
+      });
+
+      expect(resp).toEqual({
+        code: 200,
+        data: {},
+        ok: true,
+        response: httpResponse,
+      });
+    });
+
+    it('should send empty array to clear default roles', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => {},
+        clone: () => ({
+          json: () => Promise.resolve({}),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const resp = await management.tenant.updateDefaultRoles('t1', []);
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.tenant.updateDefaultRoles, {
+        id: 't1',
+        defaultRoles: [],
+      });
+
+      expect(resp).toEqual({
+        code: 200,
+        data: {},
+        ok: true,
+        response: httpResponse,
+      });
+    });
+  });
+
   describe('delete', () => {
     it('should send the correct request and receive correct response', async () => {
       const httpResponse = {

--- a/lib/management/tenant.ts
+++ b/lib/management/tenant.ts
@@ -75,6 +75,8 @@ const withTenant = (httpClient: HttpClient) => ({
         roleInheritance,
       }),
     ),
+  updateDefaultRoles: (id: string, defaultRoles: string[]): Promise<SdkResponse<never>> =>
+    transformResponse(httpClient.post(apiPaths.tenant.updateDefaultRoles, { id, defaultRoles })),
   delete: (id: string, cascade?: boolean): Promise<SdkResponse<never>> =>
     transformResponse(httpClient.post(apiPaths.tenant.delete, { id, cascade })),
   load: (id: string): Promise<SdkResponse<Tenant>> =>

--- a/lib/management/types.ts
+++ b/lib/management/types.ts
@@ -170,6 +170,7 @@ export type Tenant = {
   authType?: 'none' | 'saml' | 'oidc';
   enforceSSO?: boolean;
   disabled?: boolean;
+  defaultRoles?: string[];
 };
 
 /** Represents settings of a tenant in a project. It has an id, a name and an array of


### PR DESCRIPTION
## Summary
- Add `tenant.updateDefaultRoles(id, defaultRoles)` method to the management SDK
- Add `defaultRoles` field to the `Tenant` response type
- Add `updateDefaultRoles` API path
- Add README usage example

## Context
The backend `POST /v1/mgmt/tenant/updateDefaultRoles` endpoint already exists but was not exposed in the Node SDK. This allows users to set project-level default roles on tenants via the management API.

Closes descope/etc#14983

## Test plan
- [x] Unit test: setting default roles with role names
- [x] Unit test: clearing default roles with empty array
- [x] All 16 tenant tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)