### PR TITLE
feat: add WS-Fed SSO application management

### DIFF
--- a/README.md
+++ b/README.md
@@ -725,6 +725,14 @@ await descopeClient.management.ssoApplication.createSamlApplication({
   metadataUrl: 'http://dummy.com/metadata',
 });
 
+// Create WS-Fed SSO application
+await descopeClient.management.ssoApplication.createWsFedApplication({
+  name: 'My WS-Fed app name',
+  loginPageUrl: 'http://dummy.com/login',
+  realm: 'urn:myapp:realm',
+  replyUrl: 'http://dummy.com/reply',
+});
+
 // Update OIDC SSO application.
 // Update will override all fields as is. Use carefully.
 await descopeClient.management.ssoApplication.updateOidcApplication({
@@ -743,6 +751,18 @@ await descopeClient.management.ssoApplication.updateSamlApplication({
   useMetadataInfo: false,
   entityId: 'entity1234',
   aceUrl: 'http://dummy.com/acs',
+  certificate: 'certificate',
+});
+
+// Update WS-Fed SSO application.
+// Update will override all fields as is. Use carefully.
+await descopeClient.management.ssoApplication.updateWsFedApplication({
+  id: 'my-app-id',
+  name: 'My WS-Fed app name',
+  loginPageUrl: 'http://dummy.com/login',
+  enabled: true,
+  realm: 'urn:myapp:realm',
+  replyUrl: 'http://dummy.com/reply',
   certificate: 'certificate',
 });
 

--- a/README.md
+++ b/README.md
@@ -763,7 +763,6 @@ await descopeClient.management.ssoApplication.updateWsFedApplication({
   enabled: true,
   realm: 'urn:myapp:realm',
   replyUrl: 'http://dummy.com/reply',
-  certificate: 'certificate',
 });
 
 // SSO application deletion cannot be undone. Use carefully.

--- a/examples/managementCli/src/index.ts
+++ b/examples/managementCli/src/index.ts
@@ -728,6 +728,26 @@ program
     );
   });
 
+// sso-application-create-wsfed
+program
+  .command('sso-application-create-wsfed')
+  .description('Create a new WS-Fed sso application')
+  .argument('<name>', 'sso application name')
+  .argument('<loginPageUrl>', 'The URL where login page is hosted')
+  .argument('<realm>', 'WS-Fed realm identifier')
+  .argument('<replyUrl>', 'WS-Fed reply URL')
+  .action(async (name, loginPageUrl, realm, replyUrl) => {
+    handleSdkRes(
+      await sdk.management.ssoApplication.createWsFedApplication({
+        name,
+        loginPageUrl,
+        enabled: true,
+        realm,
+        replyUrl,
+      }),
+    );
+  });
+
 // sso-application-update-oidc
 program
   .command('sso-application-update-oidc')
@@ -765,6 +785,30 @@ program
         useMetadataInfo: false,
         entityId,
         acsUrl,
+        certificate,
+      }),
+    );
+  });
+
+// sso-application-update-wsfed
+program
+  .command('sso-application-update-wsfed')
+  .description('Update a WS-Fed sso application')
+  .argument('<id>', 'sso application ID')
+  .argument('<name>', 'sso application name')
+  .argument('<loginPageUrl>', 'The URL where login page is hosted')
+  .argument('<realm>', 'WS-Fed realm identifier')
+  .argument('<replyUrl>', 'WS-Fed reply URL')
+  .argument('<certificate>', 'SP certificate')
+  .action(async (id, name, loginPageUrl, realm, replyUrl, certificate) => {
+    handleSdkRes(
+      await sdk.management.ssoApplication.updateWsFedApplication({
+        id,
+        name,
+        loginPageUrl,
+        enabled: true,
+        realm,
+        replyUrl,
         certificate,
       }),
     );

--- a/examples/managementCli/src/index.ts
+++ b/examples/managementCli/src/index.ts
@@ -799,8 +799,7 @@ program
   .argument('<loginPageUrl>', 'The URL where login page is hosted')
   .argument('<realm>', 'WS-Fed realm identifier')
   .argument('<replyUrl>', 'WS-Fed reply URL')
-  .argument('<certificate>', 'SP certificate')
-  .action(async (id, name, loginPageUrl, realm, replyUrl, certificate) => {
+  .action(async (id, name, loginPageUrl, realm, replyUrl) => {
     handleSdkRes(
       await sdk.management.ssoApplication.updateWsFedApplication({
         id,
@@ -809,7 +808,6 @@ program
         enabled: true,
         realm,
         replyUrl,
-        certificate,
       }),
     );
   });

--- a/lib/management/paths.ts
+++ b/lib/management/paths.ts
@@ -78,6 +78,8 @@ export default {
     samlCreate: '/v1/mgmt/sso/idp/app/saml/create',
     oidcUpdate: '/v1/mgmt/sso/idp/app/oidc/update',
     samlUpdate: '/v1/mgmt/sso/idp/app/saml/update',
+    wsfedCreate: '/v1/mgmt/sso/idp/app/wsfed/create',
+    wsfedUpdate: '/v1/mgmt/sso/idp/app/wsfed/update',
     delete: '/v1/mgmt/sso/idp/app/delete',
     load: '/v1/mgmt/sso/idp/app/load',
     loadAll: '/v1/mgmt/sso/idp/apps/load',

--- a/lib/management/ssoapplication.test.ts
+++ b/lib/management/ssoapplication.test.ts
@@ -309,6 +309,145 @@ describe('Management SSOApplication', () => {
     });
   });
 
+  describe('createWsFedApplication', () => {
+    it('should send the correct request and receive correct response', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => mockSSOApplicationCreateResponse,
+        clone: () => ({
+          json: () => Promise.resolve(mockSSOApplicationCreateResponse),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const resp: SdkResponse<CreateSSOApplicationResponse> =
+        await management.ssoApplication.createWsFedApplication({
+          name: 'name',
+          loginPageUrl: 'http://dummy.com',
+          realm: 'urn:myapp:realm',
+          replyUrl: 'http://dummy.com/reply',
+          forceAuthentication: true,
+          logoutRedirectUrl: 'http://dummy.com/logout',
+          errorRedirectUrl: 'http://dummy.com/error',
+        });
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.ssoApplication.wsfedCreate, {
+        name: 'name',
+        loginPageUrl: 'http://dummy.com',
+        id: undefined,
+        description: undefined,
+        logo: undefined,
+        enabled: true,
+        realm: 'urn:myapp:realm',
+        replyUrl: 'http://dummy.com/reply',
+        attributeMapping: undefined,
+        groupsMapping: undefined,
+        forceAuthentication: true,
+        logoutRedirectUrl: 'http://dummy.com/logout',
+        errorRedirectUrl: 'http://dummy.com/error',
+      });
+
+      expect(resp).toEqual({
+        code: 200,
+        data: mockSSOApplicationCreateResponse,
+        ok: true,
+        response: httpResponse,
+      });
+    });
+
+    it('should allow false to be sent in the enabled flag', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => mockSSOApplicationCreateResponse,
+        clone: () => ({
+          json: () => Promise.resolve(mockSSOApplicationCreateResponse),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const resp: SdkResponse<CreateSSOApplicationResponse> =
+        await management.ssoApplication.createWsFedApplication({
+          name: 'name',
+          loginPageUrl: 'http://dummy.com',
+          enabled: false,
+          realm: 'urn:myapp:realm',
+          replyUrl: 'http://dummy.com/reply',
+        });
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.ssoApplication.wsfedCreate, {
+        name: 'name',
+        loginPageUrl: 'http://dummy.com',
+        id: undefined,
+        description: undefined,
+        logo: undefined,
+        enabled: false,
+        realm: 'urn:myapp:realm',
+        replyUrl: 'http://dummy.com/reply',
+        attributeMapping: undefined,
+        groupsMapping: undefined,
+        forceAuthentication: undefined,
+        logoutRedirectUrl: undefined,
+        errorRedirectUrl: undefined,
+      });
+
+      expect(resp).toEqual({
+        code: 200,
+        data: mockSSOApplicationCreateResponse,
+        ok: true,
+        response: httpResponse,
+      });
+    });
+  });
+
+  describe('updateWsFedApplication', () => {
+    it('should send the correct request and receive correct response', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => {},
+        clone: () => ({
+          json: () => Promise.resolve({}),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const resp = await management.ssoApplication.updateWsFedApplication({
+        id: 'app1',
+        name: 'name',
+        loginPageUrl: 'http://dummy.com',
+        enabled: true,
+        realm: 'urn:myapp:realm',
+        replyUrl: 'http://dummy.com/reply',
+        errorRedirectUrl: 'http://dummy.com/error',
+      });
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.ssoApplication.wsfedUpdate, {
+        id: 'app1',
+        name: 'name',
+        loginPageUrl: 'http://dummy.com',
+        description: undefined,
+        logo: undefined,
+        enabled: true,
+        realm: 'urn:myapp:realm',
+        replyUrl: 'http://dummy.com/reply',
+        attributeMapping: undefined,
+        groupsMapping: undefined,
+        forceAuthentication: undefined,
+        logoutRedirectUrl: undefined,
+        errorRedirectUrl: undefined,
+      });
+
+      expect(resp).toEqual({
+        code: 200,
+        data: {},
+        ok: true,
+        response: httpResponse,
+      });
+    });
+  });
+
   describe('delete', () => {
     it('should send the correct request and receive correct response', async () => {
       const httpResponse = {

--- a/lib/management/ssoapplication.test.ts
+++ b/lib/management/ssoapplication.test.ts
@@ -436,7 +436,7 @@ describe('Management SSOApplication', () => {
         groupsMapping: undefined,
         forceAuthentication: undefined,
         logoutRedirectUrl: undefined,
-        errorRedirectUrl: undefined,
+        errorRedirectUrl: 'http://dummy.com/error',
       });
 
       expect(resp).toEqual({

--- a/lib/management/ssoapplication.ts
+++ b/lib/management/ssoapplication.ts
@@ -5,6 +5,7 @@ import {
   SSOApplication,
   OidcApplicationOptions,
   SamlApplicationOptions,
+  WsFedApplicationOptions,
 } from './types';
 
 type MultipleSSOApplicationResponse = {
@@ -38,6 +39,19 @@ const withSSOApplication = (httpClient: HttpClient) => ({
     options: SamlApplicationOptions & { id: string },
   ): Promise<SdkResponse<never>> =>
     transformResponse(httpClient.post(apiPaths.ssoApplication.samlUpdate, { ...options })),
+  createWsFedApplication: (
+    options: WsFedApplicationOptions,
+  ): Promise<SdkResponse<CreateSSOApplicationResponse>> =>
+    transformResponse(
+      httpClient.post(apiPaths.ssoApplication.wsfedCreate, {
+        ...options,
+        enabled: options.enabled ?? true,
+      }),
+    ),
+  updateWsFedApplication: (
+    options: WsFedApplicationOptions & { id: string },
+  ): Promise<SdkResponse<never>> =>
+    transformResponse(httpClient.post(apiPaths.ssoApplication.wsfedUpdate, { ...options })),
   delete: (id: string): Promise<SdkResponse<never>> =>
     transformResponse(httpClient.post(apiPaths.ssoApplication.delete, { id })),
   load: (id: string): Promise<SdkResponse<SSOApplication>> =>

--- a/lib/management/types.ts
+++ b/lib/management/types.ts
@@ -277,6 +277,8 @@ export type SSOApplicationWSFedSettings = {
   errorRedirectUrl: string;
   idpInitiatedUrl?: string;
   idpMetadataUrl?: string;
+  idpEntityId?: string;
+  idpSsoUrl?: string;
   idpCert?: string;
 };
 

--- a/lib/management/types.ts
+++ b/lib/management/types.ts
@@ -79,8 +79,8 @@ export type WsFedApplicationOptions = {
   description?: string;
   logo?: string;
   enabled?: boolean;
-  realm?: string;
-  replyUrl?: string;
+  realm: string;
+  replyUrl: string;
   attributeMapping?: SamlIdpAttributeMappingInfo[];
   groupsMapping?: SamlIdpGroupsMappingInfo[];
   forceAuthentication?: boolean;
@@ -290,7 +290,7 @@ export type SSOApplication = {
   appType: string;
   samlSettings: SSOApplicationSAMLSettings;
   oidcSettings: SSOApplicationOIDCSettings;
-  wsfedSettings: SSOApplicationWSFedSettings;
+  wsfedSettings?: SSOApplicationWSFedSettings;
 };
 
 /** Represents a permission in a project. It has a name and optionally a description.

--- a/lib/management/types.ts
+++ b/lib/management/types.ts
@@ -68,6 +68,27 @@ export type SamlApplicationOptions = {
 };
 
 /**
+ * Options to create or update a WS-Fed application.
+ *
+ * **Note:** When updating, `id` will be required to perform the operation
+ */
+export type WsFedApplicationOptions = {
+  name: string;
+  loginPageUrl: string;
+  id?: string;
+  description?: string;
+  logo?: string;
+  enabled?: boolean;
+  realm?: string;
+  replyUrl?: string;
+  attributeMapping?: SamlIdpAttributeMappingInfo[];
+  groupsMapping?: SamlIdpGroupsMappingInfo[];
+  forceAuthentication?: boolean;
+  logoutRedirectUrl?: string;
+  errorRedirectUrl?: string;
+};
+
+/**
  * Represents a SAML IDP attribute mapping object. Use this class for mapping Descope attribute
  * to the relevant SAML Assertion attributes matching your expected SP attributes names.
  */
@@ -244,6 +265,21 @@ export type SSOApplicationSAMLSettings = {
   defaultSignatureAlgorithm?: string;
 };
 
+/** Represents WS-Fed settings of an SSO application in a project. */
+export type SSOApplicationWSFedSettings = {
+  loginPageUrl: string;
+  realm: string;
+  replyUrl: string;
+  attributeMapping: SamlIdpAttributeMappingInfo[];
+  groupsMapping: SamlIdpGroupsMappingInfo[];
+  forceAuthentication: boolean;
+  logoutRedirectUrl: string;
+  errorRedirectUrl: string;
+  idpInitiatedUrl?: string;
+  idpMetadataUrl?: string;
+  idpCert?: string;
+};
+
 /** Represents an SSO application in a project. */
 export type SSOApplication = {
   id: string;
@@ -254,6 +290,7 @@ export type SSOApplication = {
   appType: string;
   samlSettings: SSOApplicationSAMLSettings;
   oidcSettings: SSOApplicationOIDCSettings;
+  wsfedSettings: SSOApplicationWSFedSettings;
 };
 
 /** Represents a permission in a project. It has a name and optionally a description.

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "rollup-plugin-terser": "^7.0.2",
         "ts-jest": "^29.0.0",
         "ts-node": "^10.8.2",
-        "typescript": "^4.6.4"
+        "typescript": "^6.0.0"
       },
       "engines": {
         "node": ">= 16.0.0"
@@ -836,21 +836,6 @@
         "@types/node": "*",
         "cosmiconfig": ">=9",
         "typescript": ">=5"
-      }
-    },
-    "node_modules/@commitlint/load/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/@commitlint/message": {
@@ -13129,16 +13114,17 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/ua-parser-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "rollup-plugin-terser": "^7.0.2",
         "ts-jest": "^29.0.0",
         "ts-node": "^10.8.2",
-        "typescript": "^6.0.0"
+        "typescript": "^4.6.4"
       },
       "engines": {
         "node": ">= 16.0.0"
@@ -836,6 +836,21 @@
         "@types/node": "*",
         "cosmiconfig": ">=9",
         "typescript": ">=5"
+      }
+    },
+    "node_modules/@commitlint/load/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@commitlint/message": {
@@ -13114,17 +13129,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/ua-parser-js": {


### PR DESCRIPTION
## Related Issues
Required for:
https://github.com/descope/etc/issues/15054

## Description
Add createWsFedApplication, updateWsFedApplication methods and types for managing WS-Federation SSO applications via the Node management SDK.

## Must
- [ ] Tests
- [ ] Documentation (if applicable)