### PR TITLE
fix(tenant): correct TenantSettings type to match proto API

### DIFF
--- a/lib/management/tenant.test.ts
+++ b/lib/management/tenant.test.ts
@@ -24,7 +24,7 @@ const mockTenants = [
 const mockSettings: TenantSettings = {
   domains: ['domain1.com'],
   selfProvisioningDomains: ['domain1.com'],
-  sessionSettingsEnabled: true,
+  enabled: true,
   refreshTokenExpiration: 12,
   refreshTokenExpirationUnit: 'days',
   sessionTokenExpiration: 10,

--- a/lib/management/types.ts
+++ b/lib/management/types.ts
@@ -194,6 +194,20 @@ export type Tenant = {
   defaultRoles?: string[];
 };
 
+export type SSOSetupSuiteSettingsDisabledFeatures = {
+  saml?: boolean;
+  oidc?: boolean;
+  scim?: boolean;
+  ssoDomains?: boolean;
+  groupMapping?: boolean;
+};
+
+export type SSOSetupSuiteSettings = {
+  enabled?: boolean;
+  styleId?: string;
+  disabledFeatures?: SSOSetupSuiteSettingsDisabledFeatures;
+};
+
 /** Represents settings of a tenant in a project. It has an id, a name and an array of
  * self provisioning domains used to associate users with that tenant.
  */
@@ -201,7 +215,7 @@ export type TenantSettings = {
   selfProvisioningDomains: string[];
   domains?: string[];
   authType?: 'none' | 'saml' | 'oidc';
-  sessionSettingsEnabled?: boolean;
+  enabled?: boolean;
   refreshTokenExpiration?: number;
   refreshTokenExpirationUnit?: ExpirationUnit;
   sessionTokenExpiration?: number;
@@ -212,6 +226,7 @@ export type TenantSettings = {
   InactivityTime?: number;
   InactivityTimeUnit?: ExpirationUnit;
   JITDisabled?: boolean;
+  ssoSetupSuiteSettings?: SSOSetupSuiteSettings;
 };
 
 /** Represents password settings of a tenant in a project. It has the password policy details. */


### PR DESCRIPTION
## Summary
- Renames `sessionSettingsEnabled` → `enabled` in `TenantSettings` to match the `ConfigureTenantSettingsRequest` proto field — the old name was silently ignored by the API
- Adds missing `ssoSetupSuiteSettings?: SSOSetupSuiteSettings` field to `TenantSettings`
- Adds new exported types `SSOSetupSuiteSettings` and `SSOSetupSuiteSettingsDisabledFeatures`

Fixes https://github.com/descope/etc/issues/15202

## Test plan
- [ ] Verify `configureSettings` correctly sends `enabled` in the request body
- [ ] Verify `getSettings` response maps to `enabled` correctly
- [ ] Verify `ssoSetupSuiteSettings` can be passed through `configureSettings`
- [ ] TypeScript compilation passes with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)