### PR TITLE
feat(user): add locale option to invite and invite-batch

### DIFF
--- a/lib/management/user.test.ts
+++ b/lib/management/user.test.ts
@@ -308,6 +308,50 @@ describe('Management User', () => {
       });
     });
 
+    it('should send locale via the positional arguments overload', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => mockMgmtUserResponse,
+        clone: () => ({
+          json: () => Promise.resolve(mockMgmtUserResponse),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      await management.user.invite(
+        'loginId',
+        'a@b.c',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'en-US',
+      );
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        apiPaths.user.create,
+        expect.objectContaining({
+          loginId: 'loginId',
+          email: 'a@b.c',
+          locale: 'en-US',
+          invite: true,
+        }),
+      );
+    });
+
     it('should send the correct request and receive correct response with options argument', async () => {
       const httpResponse = {
         ok: true,

--- a/lib/management/user.test.ts
+++ b/lib/management/user.test.ts
@@ -326,6 +326,7 @@ describe('Management User', () => {
         inviteUrl: 'https://invite.me',
         sendMail: true,
         templateOptions: { k1: 'v1' },
+        locale: 'en-US',
       });
 
       expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.create, {
@@ -337,6 +338,7 @@ describe('Management User', () => {
         inviteUrl: 'https://invite.me',
         sendMail: true,
         templateOptions: { k1: 'v1' },
+        locale: 'en-US',
       });
 
       expect(resp).toEqual({
@@ -407,6 +409,10 @@ describe('Management User', () => {
         ],
         'https://invite.me',
         true,
+        undefined,
+        undefined,
+        undefined,
+        'fr-FR',
       );
 
       expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.createBatch, {
@@ -437,6 +443,7 @@ describe('Management User', () => {
         invite: true,
         inviteUrl: 'https://invite.me',
         sendMail: true,
+        locale: 'fr-FR',
       });
 
       expect(resp).toEqual({

--- a/lib/management/user.ts
+++ b/lib/management/user.ts
@@ -230,6 +230,7 @@ const withUser = (httpClient: HttpClient) => {
       sendSMS?: boolean; // send invite via text message, default is according to project settings
       templateOptions?: TemplateOptions;
       templateId?: string;
+      locale?: string; // locale for the invite message
     },
   ): Promise<SdkResponse<UserResponse>>;
   function invite(
@@ -251,6 +252,7 @@ const withUser = (httpClient: HttpClient) => {
     familyName?: string,
     additionalLoginIds?: string[],
     templateId?: string,
+    locale?: string, // locale for the invite message
   ): Promise<SdkResponse<UserResponse>>;
 
   function invite(
@@ -272,6 +274,7 @@ const withUser = (httpClient: HttpClient) => {
     familyName?: string,
     additionalLoginIds?: string[],
     templateId?: string,
+    locale?: string, // locale for the invite message
   ): Promise<SdkResponse<UserResponse>> {
     // We support both the old and new parameters forms of invite user
     // 1. The new form - invite(loginIdOrUserId, { email, phone, ... }})
@@ -298,6 +301,7 @@ const withUser = (httpClient: HttpClient) => {
             sendSMS,
             additionalLoginIds,
             templateId,
+            locale,
           }
         : {
             loginId: loginIdOrUserId,
@@ -511,6 +515,7 @@ const withUser = (httpClient: HttpClient) => {
       sendSMS?: boolean, // send invite via text message, default is according to project settings
       templateOptions?: TemplateOptions,
       templateId?: string,
+      locale?: string, // locale for the invite message
     ): Promise<SdkResponse<CreateOrInviteBatchResponse>> =>
       transformResponse<CreateOrInviteBatchResponse, CreateOrInviteBatchResponse>(
         httpClient.post(apiPaths.user.createBatch, {
@@ -521,6 +526,7 @@ const withUser = (httpClient: HttpClient) => {
           sendSMS,
           templateOptions,
           templateId,
+          locale,
         }),
         (data) => data,
       ),


### PR DESCRIPTION
## Related Issues
N/A

## Description
Plumb a `locale` string through both forms of `invite()` (options-object and positional) and through `inviteBatch()` so callers can override which message-template variant the backend sends out with the invite. Mirrors patterns elsewhere in the SDK that already expose a per-call `locale`.

- `user.ts` — add `locale?: string` to the options-object overload, the positional overload, and forward it in the body of both `invite` and `inviteBatch`
- `user.test.ts` — assert the field reaches the wire on both paths

## Must
- [x] Tests
- [ ] Documentation (if applicable)