### PR TITLE
fix(user): accept password/hashed password fields in create user

### DIFF
--- a/lib/management/types.ts
+++ b/lib/management/types.ts
@@ -971,6 +971,9 @@ export interface UserOptions {
   familyName?: string;
   additionalLoginIds?: string[];
   ssoAppIds?: string[];
+  password?: string;
+  hashedPassword?: UserPasswordHashed;
+  seed?: string;
 }
 
 export type MgmtUserOptions = Omit<

--- a/lib/management/user.test.ts
+++ b/lib/management/user.test.ts
@@ -181,6 +181,61 @@ describe('Management User', () => {
         response: httpResponse,
       });
     });
+
+    it('should send password and hashed password with options argument', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => mockMgmtUserResponse,
+        clone: () => ({
+          json: () => Promise.resolve(mockMgmtUserResponse),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const hashed: UserPasswordHashed = {
+        firebase: {
+          hash: 'h',
+          salt: 's',
+          saltSeparator: 'ss',
+          signerKey: 'sk',
+          memory: 14,
+          rounds: 8,
+        },
+      };
+
+      const resp: SdkResponse<UserResponse> = await management.user.create('loginId', {
+        email: 'a@b.c',
+        password: 'cleartext',
+        hashedPassword: hashed,
+        seed: 'totp-seed',
+      });
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.create, {
+        loginId: 'loginId',
+        email: 'a@b.c',
+        password: 'cleartext',
+        hashedPassword: {
+          firebase: {
+            hash: 'h',
+            salt: 's',
+            saltSeparator: 'ss',
+            signerKey: 'sk',
+            memory: 14,
+            rounds: 8,
+          },
+        },
+        seed: 'totp-seed',
+        roleNames: undefined,
+      });
+
+      expect(resp).toEqual({
+        code: 200,
+        data: mockUserResponse,
+        ok: true,
+        response: httpResponse,
+      });
+    });
   });
 
   describe('createTestUser', () => {


### PR DESCRIPTION
Fixes descope/etc#16186

[View workflow run](https://github.com/descope/shuni/actions/runs/27369664366)

Done. Here's what I changed:

**`lib/management/types.ts`** — Added `password`, `hashedPassword`, and `seed` fields to the `UserOptions` interface. Since `create`, `createTestUser`, `update`, and `invite` all spread `UserOptions` into the request body, these fields now flow through to the API automatically.

**`lib/management/user.test.ts`** — Added a test verifying that `create` correctly passes `password`, `hashedPassword`, and `seed` in the request body when using the options-style API.

The fix is minimal because the infrastructure already existed — `UserPasswordHashed` types were defined, batch operations already used them, and all single-user functions used the spread operator on `UserOptions`. The only gap was the interface definition.

---
*Created by [Shuni](https://github.com/descope/shuni) 🐕*