### PR TITLE
feat(sso): add entityId to configureSAMLByMetadata settings

### DIFF
--- a/lib/management/sso.test.ts
+++ b/lib/management/sso.test.ts
@@ -409,6 +409,7 @@ describe('Management SSO', () => {
         't1',
         {
           idpMetadataUrl: 'https://metadata.com',
+          entityId: 'https://idp.example.com/entity',
           attributeMapping: { name: 'IDP_NAME', email: 'IDP_MAIL' },
           spACSUrl: 'https://spacs.url',
           spEntityId: 'spentityid',
@@ -422,6 +423,7 @@ describe('Management SSO', () => {
         tenantId: 't1',
         settings: {
           idpMetadataUrl: 'https://metadata.com',
+          entityId: 'https://idp.example.com/entity',
           attributeMapping: { name: 'IDP_NAME', email: 'IDP_MAIL' },
           spACSUrl: 'https://spacs.url',
           spEntityId: 'spentityid',

--- a/lib/management/types.ts
+++ b/lib/management/types.ts
@@ -619,6 +619,8 @@ export type SSOSAMLSettings = {
 
 export type SSOSAMLByMetadataSettings = {
   idpMetadataUrl: string;
+  /** IdP entity ID - set so IdP-initiated login can resolve the tenant by the SAML response issuer */
+  entityId?: string;
   roleMappings?: RoleMappings;
   attributeMapping?: AttributeMapping;
   defaultSSORoles?: string[];


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/16175

## Description

Adds an optional `entityId` field to `SSOSAMLByMetadataSettings`, so callers of `management.sso.configureSAMLByMetadata` can persist the IdP entity ID alongside a metadata URL.

This lets **IdP-initiated SAML login resolve the tenant by the SAML response issuer**. Without it, metadata-configured tenants had no stored entity ID and the issuer lookup failed (reported by Navan during SSO migration).

Backend PR: descope/backend#1280

## Must
- [x] Tests
- [x] Documentation (if applicable)