### PR TITLE
feat(tenant): add optional userId/loginId actor to generateSSOConfigurationLink

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,6 +679,20 @@ const res = await descopeClient.management.tenant.generateSSOConfigurationLink(
   60 * 60 * 24,
 );
 console.log(res.adminSSOConfigurationLink);
+
+// Optionally bind the link to a real user (by userId or loginId) so actions taken inside the
+// SSO Suite are audited against that user instead of a temporary one. The user must exist and
+// belong to the tenant; userId takes precedence over loginId.
+const resWithActor = await descopeClient.management.tenant.generateSSOConfigurationLink(
+  'my-tenant-id',
+  60 * 60 * 24,
+  undefined, // ssoId
+  undefined, // email
+  undefined, // templateId
+  undefined, // userId
+  'admin@my-tenant.com', // loginId
+);
+console.log(resWithActor.adminSSOConfigurationLink);
 ```
 
 ### Manage Password

--- a/README.md
+++ b/README.md
@@ -680,17 +680,15 @@ const res = await descopeClient.management.tenant.generateSSOConfigurationLink(
 );
 console.log(res.adminSSOConfigurationLink);
 
-// Optionally bind the link to a real user (by userId or loginId) so actions taken inside the
-// SSO Suite are audited against that user instead of a temporary one. The user must exist and
-// belong to the tenant; userId takes precedence over loginId.
+// Optionally set an actor id, recorded as the audit actor for actions taken inside the SSO
+// Suite (instead of the temporary user). It is used as-is for audit attribution and is not validated.
 const resWithActor = await descopeClient.management.tenant.generateSSOConfigurationLink(
   'my-tenant-id',
   60 * 60 * 24,
   undefined, // ssoId
   undefined, // email
   undefined, // templateId
-  undefined, // userId
-  'admin@my-tenant.com', // loginId
+  'my-admin-actor-id', // actorId
 );
 console.log(resWithActor.adminSSOConfigurationLink);
 ```

--- a/lib/management/tenant.test.ts
+++ b/lib/management/tenant.test.ts
@@ -583,5 +583,40 @@ describe('Management Tenant', () => {
         response: httpResponse,
       });
     });
+
+    it('should send the actor userId and loginId when provided', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => ({
+          adminSSOConfigurationLink: 'some link',
+        }),
+        clone: () => ({
+          json: () => Promise.resolve({ adminSSOConfigurationLink: 'some link' }),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      await management.tenant.generateSSOConfigurationLink(
+        'test',
+        60 * 60 * 24,
+        undefined,
+        undefined,
+        undefined,
+        'user-1',
+        'admin@aa.com',
+      );
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        apiPaths.tenant.generateSSOConfigurationLink,
+        {
+          tenantId: 'test',
+          expireTime: 60 * 60 * 24,
+          userId: 'user-1',
+          loginId: 'admin@aa.com',
+        },
+        {},
+      );
+    });
   });
 });

--- a/lib/management/tenant.test.ts
+++ b/lib/management/tenant.test.ts
@@ -584,7 +584,7 @@ describe('Management Tenant', () => {
       });
     });
 
-    it('should send the actor userId and loginId when provided', async () => {
+    it('should send the actorId when provided', async () => {
       const httpResponse = {
         ok: true,
         json: () => ({
@@ -603,8 +603,7 @@ describe('Management Tenant', () => {
         undefined,
         undefined,
         undefined,
-        'user-1',
-        'admin@aa.com',
+        'admin-actor-1',
       );
 
       expect(mockHttpClient.post).toHaveBeenCalledWith(
@@ -612,8 +611,7 @@ describe('Management Tenant', () => {
         {
           tenantId: 'test',
           expireTime: 60 * 60 * 24,
-          userId: 'user-1',
-          loginId: 'admin@aa.com',
+          actorId: 'admin-actor-1',
         },
         {},
       );

--- a/lib/management/tenant.ts
+++ b/lib/management/tenant.ts
@@ -123,16 +123,15 @@ const withTenant = (httpClient: HttpClient) => ({
     ssoId?: string,
     email?: string,
     templateId?: string,
-    // When provided, the SSO Setup Suite session is attributed to that real user so actions
-    // are audited against them instead of a temporary user. The user must exist and belong to
-    // the tenant. userId takes precedence over loginId.
-    userId?: string,
-    loginId?: string,
+    // When provided, actorId is recorded as the audit actor for actions performed inside the
+    // SSO Setup Suite (instead of the temporary user). It is used as-is for audit attribution
+    // and is not validated.
+    actorId?: string,
   ): Promise<SdkResponse<GenerateSSOConfigurationLinkResponse>> =>
     transformResponse<GenerateSSOConfigurationLinkResponse, GenerateSSOConfigurationLinkResponse>(
       httpClient.post(
         apiPaths.tenant.generateSSOConfigurationLink,
-        { tenantId, expireTime: expireDuration, ssoId, email, templateId, userId, loginId },
+        { tenantId, expireTime: expireDuration, ssoId, email, templateId, actorId },
         {},
       ),
       (data) => data,

--- a/lib/management/tenant.ts
+++ b/lib/management/tenant.ts
@@ -123,11 +123,16 @@ const withTenant = (httpClient: HttpClient) => ({
     ssoId?: string,
     email?: string,
     templateId?: string,
+    // When provided, the SSO Setup Suite session is attributed to that real user so actions
+    // are audited against them instead of a temporary user. The user must exist and belong to
+    // the tenant. userId takes precedence over loginId.
+    userId?: string,
+    loginId?: string,
   ): Promise<SdkResponse<GenerateSSOConfigurationLinkResponse>> =>
     transformResponse<GenerateSSOConfigurationLinkResponse, GenerateSSOConfigurationLinkResponse>(
       httpClient.post(
         apiPaths.tenant.generateSSOConfigurationLink,
-        { tenantId, expireTime: expireDuration, ssoId, email, templateId },
+        { tenantId, expireTime: expireDuration, ssoId, email, templateId, userId, loginId },
         {},
       ),
       (data) => data,


### PR DESCRIPTION
## Description
`management.tenant.generateSSOConfigurationLink` now accepts optional trailing `userId` and `loginId` params. When provided, the SSO Setup Suite session is attributed to that real user (who must exist and belong to the tenant) so actions performed inside the suite are audited against them instead of the temporary user. `userId` takes precedence over `loginId`; omitting them preserves existing behavior.

Pairs with the backend change: descope/backend#1335 (resolves descope/etc#16281).

## Changes
- `userId`/`loginId` added to the method signature and request body.
- README + unit test.