### PR TITLE
fix(fetch): prefer native fetch to avoid node-fetch premature close

### DIFF
--- a/lib/fetch-polyfill.ts
+++ b/lib/fetch-polyfill.ts
@@ -19,4 +19,13 @@ const patchedFetch = (...args: Parameters<typeof crossFetch>) => {
   return crossFetch(...args);
 };
 
-export default patchedFetch as unknown as typeof fetch;
+// node-fetch@2 (bundled by cross-fetch) throws a false ERR_STREAM_PREMATURE_CLOSE on
+// keep-alive responses on Node >= 22.23.0 / 24.17.0 (nodejs/node#63989, the CVE-2026-48931
+// http.Agent fix). Node's built-in fetch (undici, Node >= 18) is unaffected, so prefer it
+// when present and fall back to cross-fetch (node-fetch) only on older runtimes.
+const polyfillFetch =
+  typeof globalThis.fetch === 'function'
+    ? (...args: Parameters<typeof globalThis.fetch>) => globalThis.fetch(...args)
+    : patchedFetch;
+
+export default polyfillFetch as unknown as typeof fetch;


### PR DESCRIPTION
## Related Issues
Related: nodejs/node#63989

## Description

### Problem
On Node 22.23.0 and 24.17.0 (the June 2026 security release, CVE-2026-48931 `http.Agent` fix), `cross-fetch` -> `node-fetch@2.7.0` throws a false `FetchError: ... Premature close [ERR_STREAM_PREMATURE_CLOSE]` on keep-alive responses. Every SDK request runs through `cross-fetch`, so this breaks `validateSession`, key fetches, and management calls for any app on those runtimes (commonly hit via unpinned `node:22` / `node:24` base images). Node's built-in fetch (undici) is unaffected.

### Fix
`lib/fetch-polyfill.ts` prefers the global `fetch` (undici, Node 18+) and falls back to `cross-fetch` only on older runtimes.

### Behavior
- Before: keep-alive responses throw `ERR_STREAM_PREMATURE_CLOSE` on Node 22.23.0 / 24.17.0.
- After: requests use native fetch on Node 18+, no premature-close error. No API or config change.

### Tests
- Existing suite: 22 suites / 356 tests pass.
- Verified against a keep-alive + chunked `/v2/keys` mock on Node 22.23.0 and 24.17.0: SDK `getKey` succeeds on the native path and fails on the forced cross-fetch path. Both pass on Node 24.16.0 (unaffected release).

## Must
- [x] Tests
- [ ] Documentation (if applicable)