### PR TITLE
fix(outbound): add useDcr/dcrUrl to OutboundApplication type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1468,6 +1468,8 @@ You can create, update, delete or load outbound applications:
 
 ```typescript
 // Create an outbound application.
+// For DCR-based apps (e.g. custom MCP servers that support RFC 7591 dynamic
+// client registration), pass `useDcr: true` and `dcrUrl`.
 const { id } =
   await descopeClient.management.outboundApplication.createApplication({
     name: 'my new app',

--- a/lib/management/outboundapplication.test.ts
+++ b/lib/management/outboundapplication.test.ts
@@ -87,6 +87,44 @@ describe('Management OutboundApplication', () => {
         response: httpResponse,
       });
     });
+
+    it('should pass through DCR fields (useDcr/dcrUrl) without a cast', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => mockOutboundApplicationResponse,
+        clone: () => ({
+          json: () => Promise.resolve(mockOutboundApplicationResponse),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const resp: SdkResponse<OutboundApplication> =
+        await management.outboundApplication.createApplication({
+          name: 'dcr app',
+          description: 'custom MCP server with dynamic client registration',
+          useDcr: true,
+          dcrUrl: 'https://mcp.example.com/register',
+          pkce: true,
+          defaultRedirectUrl: 'https://api.descope.com/v1/outbound/oauth/callback',
+        });
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.outboundApplication.create, {
+        name: 'dcr app',
+        description: 'custom MCP server with dynamic client registration',
+        useDcr: true,
+        dcrUrl: 'https://mcp.example.com/register',
+        pkce: true,
+        defaultRedirectUrl: 'https://api.descope.com/v1/outbound/oauth/callback',
+      });
+
+      expect(resp).toEqual({
+        code: 200,
+        data: mockOutboundApplicationResponse.app,
+        ok: true,
+        response: httpResponse,
+      });
+    });
   });
 
   describe('createOutboundApplicationByTemplate', () => {

--- a/lib/management/types.ts
+++ b/lib/management/types.ts
@@ -1067,6 +1067,8 @@ export type OutboundApplication = {
   pkce?: boolean;
   accessType?: AccessType;
   prompt?: Array<PromptType>;
+  useDcr?: boolean;
+  dcrUrl?: string;
 };
 
 // Fields of an outbound application that can override a template's


### PR DESCRIPTION
## Related Issues
Fixes: https://github.com/descope/node-sdk/issues/746

## Changes
- Add `useDcr`/`dcrUrl` to the `OutboundApplication` type
- Adds a `createApplication` test + README note

## Must
- [x] Tests
- [x] Documentation (if applicable)