### PR TITLE
fix(deps): update @descope/core-js-sdk to ^2.64.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.8.0",
       "license": "MIT",
       "dependencies": {
-        "@descope/core-js-sdk": "^2.58.0",
+        "@descope/core-js-sdk": "^2.64.0",
         "cross-fetch": "^4.0.0",
         "jose": "5.2.2",
         "tslib": "^2.0.0"
@@ -1134,11 +1134,12 @@
       }
     },
     "node_modules/@descope/core-js-sdk": {
-      "version": "2.58.0",
-      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.58.0.tgz",
-      "integrity": "sha512-apgmtj7J/4kc17WrmzLXp89XGM3aLFLg8HhtPDpAMcUKWAlS0MJ4rlKd6Ab0WRTlUCq7Gm9DUQQgCblX8qMCkA==",
+      "version": "2.64.0",
+      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.64.0.tgz",
+      "integrity": "sha512-CRVGBA3JaIi03XNHt5ZKfdU3rdoGhDFm4gPcKYkCBaezweCG4FFqxqia86D9RNGrLqrYW2W4Bpz+bFGUwAiUgA==",
       "dependencies": {
-        "jwt-decode": "4.0.0"
+        "jwt-decode": "4.0.0",
+        "tslib": "2.8.1"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -12898,9 +12899,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "typescript": "^4.6.4"
   },
   "dependencies": {
-    "@descope/core-js-sdk": "^2.58.0",
+    "@descope/core-js-sdk": "^2.64.0",
     "cross-fetch": "^4.0.0",
     "jose": "5.2.2",
     "tslib": "^2.0.0"


### PR DESCRIPTION
## Summary

Bump `@descope/core-js-sdk` from `^2.58.0` to `^2.64.0`.

core-js-sdk 2.64.0 adds Cloudflare status code `520` ("Web Server Returned an Unknown Error") to the HTTP client's transient retry list (alongside `503`/`521`/`522`/`524`/`530`). node-sdk's HTTP layer is `fetchWrapper` from core-js-sdk, so this propagates the retry-on-520 behavior here — matching the change already made in go-sdk (descope/go-sdk#775), python-sdk (descope/python-sdk#1581), java (descope/descope-java#337), dotnet (descope/descope-dotnet#224) and php (descope/descope-php#111).

Source change: descope/descope-js#1423. Originating request: https://github.com/descope/etc/issues/14039

## Notes

- `package-lock.json` regenerated via `npm install --package-lock-only`; the only changes are the core-js-sdk resolution (2.58.0 → 2.64.0) and its `tslib` runtime dependency (deduped 2.6.2 → 2.8.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)