### PR TITLE
fix(management): add id and private fields to role type

### DIFF
--- a/lib/management/types.ts
+++ b/lib/management/types.ts
@@ -333,6 +333,8 @@ export type Role = {
   createdTime: number;
   tenantId?: string;
   default?: boolean;
+  private?: boolean;
+  id?: string;
 };
 
 /** Search roles based on the parameters */


### PR DESCRIPTION
Fixes descope/etc#16864

[View workflow run](https://github.com/descope/shuni/actions/runs/29150882882)

Done. Added `private?: boolean` and `id?: string` to the `Role` type in `lib/management/types.ts:329`. tsc passes, pre-commit lint hook passes, committed.

`[type-only fix] → skipped: nothing — the fields already exist on the wire, only the type was behind.`

---
*Created by [Shuni](https://github.com/descope/shuni) 🐕*