### PR TITLE
feat: expose lastSuccessTestTime on SSO settings load response

### DIFF
--- a/lib/management/sso.test.ts
+++ b/lib/management/sso.test.ts
@@ -554,11 +554,13 @@ describe('Management SSO', () => {
           },
           providerID: 'pidoidc',
           scimProviderID: 'scimidoidc',
+          lastSuccessTestTime: 888,
         },
         saml: {
           groupsMapping: [{ groups: ['g1', 'g2'], role: { id: 'rid', name: 'rname' } }],
           providerID: 'pidsaml',
           scimProviderID: 'scimidsaml',
+          lastSuccessTestTime: 777,
         },
       };
       const httpResponse = {
@@ -593,11 +595,13 @@ describe('Management SSO', () => {
             },
             providerID: 'pidoidc',
             scimProviderID: 'scimidoidc',
+            lastSuccessTestTime: 888,
           },
           saml: {
             groupsMapping: [{ groups: ['g1', 'g2'], roleName: 'rname' }],
             providerID: 'pidsaml',
             scimProviderID: 'scimidsaml',
+            lastSuccessTestTime: 777,
           },
         },
       });

--- a/lib/management/types.ts
+++ b/lib/management/types.ts
@@ -557,6 +557,8 @@ export type SSOSAMLSettingsResponse = {
   redirectUrl: string;
   providerID?: string;
   scimProviderID?: string;
+  /** Epoch seconds of the last successful SSO test login on this configuration (read-only) */
+  lastSuccessTestTime?: number;
 };
 
 export type SSOSettings = {
@@ -608,6 +610,8 @@ export type SSOOIDCSettings = {
   roleMappings?: OIDCRoleMapping;
   providerID?: string;
   scimProviderID?: string;
+  /** Epoch seconds of the last successful SSO test login on this configuration (read-only, ignored on configure) */
+  lastSuccessTestTime?: number;
 };
 
 export type SSOSAMLSettings = {


### PR DESCRIPTION
## Description
The management API now returns `lastSuccessTestTime` (epoch seconds of the last successful SSO test login) on tenant SSO settings load for both SAML and OIDC configurations (descope/backend#1772). Surface it on `SSOSAMLSettingsResponse` and `SSOOIDCSettings` so callers can programmatically verify a tenant's SSO configuration was tested successfully and is active.

Related: https://github.com/descope/etc/issues/16911

🤖 Generated with [Claude Code](https://claude.com/claude-code)