### PR TITLE
feat: expose external-group source on the Group model

### DIFF
--- a/lib/management/types.ts
+++ b/lib/management/types.ts
@@ -351,6 +351,8 @@ export type Group = {
   id: string;
   display: string;
   members?: GroupMember[];
+  /** Origin of the group: "scim" (default) or "jit" (SSO SAML/OIDC assertion groups). */
+  source?: string;
 };
 
 /** Represents a group member. It has loginId, userId and display. */


### PR DESCRIPTION
## What

Add an optional `source` field (`"scim"` | `"jit"`) to the management `Group` model so `loadAllGroups` / `loadAllGroupsForMembers` / `loadAllGroupMembers` callers can distinguish SCIM-provisioned groups from JIT (SSO SAML/OIDC assertion) groups.

## Why

Backend now persists JIT (SSO assertion) groups as external groups so the `{{user.idpGroups}}` claim survives token refresh, and the management group API exposes their origin via a new `source` field. This mirrors the equivalent go-sdk change so all SDKs surface it.

## Related

- go-sdk: `feat/external-group-source` (Group.Source)
- backend: descope/backend#1776

🤖 Generated with [Claude Code](https://claude.com/claude-code)