### PR TITLE
feat: add templateId parameter to management user create

### DIFF
--- a/lib/management/user.test.ts
+++ b/lib/management/user.test.ts
@@ -181,6 +181,68 @@ describe('Management User', () => {
         response: httpResponse,
       });
     });
+
+    it('should send templateId via the options argument', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => mockMgmtUserResponse,
+        clone: () => ({
+          json: () => Promise.resolve(mockMgmtUserResponse),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      await management.user.create('loginId', {
+        email: 'a@b.c',
+        templateId: 'my-template-id',
+      });
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.create, {
+        loginId: 'loginId',
+        email: 'a@b.c',
+        templateId: 'my-template-id',
+      });
+    });
+
+    it('should send templateId via the positional arguments overload', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => mockMgmtUserResponse,
+        clone: () => ({
+          json: () => Promise.resolve(mockMgmtUserResponse),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      await management.user.create(
+        'loginId',
+        'a@b.c',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'my-template-id',
+      );
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        apiPaths.user.create,
+        expect.objectContaining({
+          loginId: 'loginId',
+          email: 'a@b.c',
+          templateId: 'my-template-id',
+        }),
+      );
+    });
   });
 
   describe('createTestUser', () => {

--- a/lib/management/user.ts
+++ b/lib/management/user.ts
@@ -77,7 +77,12 @@ type MultipleUsersResponse = {
 
 const withUser = (httpClient: HttpClient) => {
   /* Create User */
-  function create(loginId: string, options?: UserOptions): Promise<SdkResponse<UserResponse>>;
+  function create(
+    loginId: string,
+    options?: UserOptions & {
+      templateId?: string;
+    },
+  ): Promise<SdkResponse<UserResponse>>;
   function create(
     loginId: string,
     email?: string,
@@ -93,6 +98,7 @@ const withUser = (httpClient: HttpClient) => {
     middleName?: string,
     familyName?: string,
     additionalLoginIds?: string[],
+    templateId?: string,
   ): Promise<SdkResponse<UserResponse>>;
 
   function create(
@@ -110,6 +116,7 @@ const withUser = (httpClient: HttpClient) => {
     middleName?: string,
     familyName?: string,
     additionalLoginIds?: string[],
+    templateId?: string,
   ): Promise<SdkResponse<UserResponse>> {
     // We support both the old and new parameters forms of create user
     // 1. The new form - create(loginId, { email, phone, ... }})
@@ -131,6 +138,7 @@ const withUser = (httpClient: HttpClient) => {
             verifiedEmail,
             verifiedPhone,
             additionalLoginIds,
+            templateId,
           }
         : {
             loginId,


### PR DESCRIPTION
## What

Add the `templateId` parameter to `management.user.create`, which was missing while `invite` / `inviteBatch` already expose it.

Wired through both call forms:
- options object: `create('loginId', { email, templateId })`
- positional overload: `create('loginId', email, ..., templateId)`

Backend `CreateUserRequest` already accepts `templateId` (proto field 29), so this is purely SDK-side plumbing over an existing wire contract.

## Why

`create` was the only message-capable user function without `templateId`. `update`/`patch` have no such proto field; `createTestUser`/`createBatch` send no message so it's a no-op there.

Closes descope/etc#17215

## Tests

Added two `create` tests (options form + positional overload). Full `user.test.ts` suite green, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)