### PR TITLE
feat(management): add enforceSSOExclusions to tenant create and update

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,17 +622,29 @@ await descopeClient.management.tenant.create(
   false, // disabled
   '', // parent tenant ID
   'none', // roleInheritance
-  ['admin@domain.com'], // enforceSSOExclusions - user IDs excluded from SSO enforcement
+  ['<user-ID>'], // enforceSSOExclusions - Descope user IDs excluded from SSO enforcement
 );
 
-// You can optionally set your own ID when creating a tenant
-await descopeClient.management.tenant.createWithId('my-custom-id', 'My Tenant', ['domain.com'], {
-  customAttributeName: 'val',
-});
+// You can optionally set your own ID when creating a tenant. It accepts the same
+// optional arguments as create, shifted one position to make room for the ID.
+await descopeClient.management.tenant.createWithId(
+  'my-custom-id',
+  'My Tenant',
+  ['domain.com'],
+  { customAttributeName: 'val' },
+  true, // enforceSSO
+  false, // disabled
+  '', // parent tenant ID
+  'none', // roleInheritance
+  ['<user-ID>'], // enforceSSOExclusions - Descope user IDs excluded from SSO enforcement
+);
 
 // Update will override all fields as is. Use carefully.
-// Any field you omit is cleared on the tenant, so read the tenant first and pass
-// back the values you want to keep.
+// Every parameter update takes is replaced, so any one you omit is cleared on the tenant -
+// read the tenant first and pass back the values you want to keep. Fields update has no
+// parameter for, such as the parent tenant and default roles, are not affected.
+// The values below are illustrative rather than defaults: copying this call as-is also
+// turns enforceSSO on.
 await descopeClient.management.tenant.update(
   'my-custom-id',
   'My Tenant',
@@ -641,7 +653,7 @@ await descopeClient.management.tenant.update(
   true, // enforceSSO
   false, // disabled
   'none', // roleInheritance
-  ['admin@domain.com'], // enforceSSOExclusions - user IDs excluded from SSO enforcement
+  ['<user-ID>'], // enforceSSOExclusions - Descope user IDs excluded from SSO enforcement
 );
 
 // Update the tenant's default roles by providing role names.

--- a/README.md
+++ b/README.md
@@ -614,9 +614,16 @@ You can create, update, delete or load tenants, as well as read and update tenan
 ```typescript
 // The self provisioning domains or optional. If given they'll be used to associate
 // Users logging in to this tenant
-await descopeClient.management.tenant.create('My Tenant', ['domain.com'], {
-  customAttributeName: 'val',
-});
+await descopeClient.management.tenant.create(
+  'My Tenant',
+  ['domain.com'],
+  { customAttributeName: 'val' },
+  true, // enforceSSO
+  false, // disabled
+  '', // parent tenant ID
+  'none', // roleInheritance
+  ['admin@domain.com'], // enforceSSOExclusions - user IDs excluded from SSO enforcement
+);
 
 // You can optionally set your own ID when creating a tenant
 await descopeClient.management.tenant.createWithId('my-custom-id', 'My Tenant', ['domain.com'], {
@@ -624,11 +631,17 @@ await descopeClient.management.tenant.createWithId('my-custom-id', 'My Tenant', 
 });
 
 // Update will override all fields as is. Use carefully.
+// Any field you omit is cleared on the tenant, so read the tenant first and pass
+// back the values you want to keep.
 await descopeClient.management.tenant.update(
   'my-custom-id',
   'My Tenant',
   ['domain.com', 'another-domain.com'],
   { customAttributeName: 'val' },
+  true, // enforceSSO
+  false, // disabled
+  'none', // roleInheritance
+  ['admin@domain.com'], // enforceSSOExclusions - user IDs excluded from SSO enforcement
 );
 
 // Update the tenant's default roles by providing role names.

--- a/lib/management/tenant.test.ts
+++ b/lib/management/tenant.test.ts
@@ -65,6 +65,7 @@ describe('Management Tenant', () => {
         true,
         'p',
         'none',
+        ['excluded@example.com'],
       );
 
       expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.tenant.create, {
@@ -72,6 +73,7 @@ describe('Management Tenant', () => {
         selfProvisioningDomains: ['d1'],
         customAttributes: { customAttr: 'value' },
         enforceSSO: true,
+        enforceSSOExclusions: ['excluded@example.com'],
         disabled: true,
         parent: 'p',
         roleInheritance: 'none',
@@ -146,6 +148,7 @@ describe('Management Tenant', () => {
         true,
         'p',
         '',
+        ['excluded@example.com'],
       );
 
       expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.tenant.create, {
@@ -154,6 +157,7 @@ describe('Management Tenant', () => {
         selfProvisioningDomains: ['d1'],
         customAttributes: { customAttr: 'value' },
         enforceSSO: true,
+        enforceSSOExclusions: ['excluded@example.com'],
         disabled: true,
         parent: 'p',
         roleInheritance: '',
@@ -227,6 +231,7 @@ describe('Management Tenant', () => {
         true,
         true,
         'none',
+        ['excluded@example.com'],
       );
 
       expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.tenant.update, {
@@ -235,6 +240,7 @@ describe('Management Tenant', () => {
         selfProvisioningDomains: ['d1'],
         customAttributes: { customAttr: 'value' },
         enforceSSO: true,
+        enforceSSOExclusions: ['excluded@example.com'],
         disabled: true,
         roleInheritance: 'none',
       });

--- a/lib/management/tenant.ts
+++ b/lib/management/tenant.ts
@@ -21,6 +21,7 @@ const withTenant = (httpClient: HttpClient) => ({
     disabled?: boolean,
     parent?: string,
     roleInheritance?: '' | 'none' | 'userOnly',
+    enforceSSOExclusions?: string[],
   ): Promise<SdkResponse<CreateTenantResponse>> =>
     transformResponse(
       httpClient.post(apiPaths.tenant.create, {
@@ -28,6 +29,7 @@ const withTenant = (httpClient: HttpClient) => ({
         selfProvisioningDomains,
         customAttributes,
         enforceSSO,
+        enforceSSOExclusions,
         disabled,
         parent,
         roleInheritance,
@@ -42,6 +44,7 @@ const withTenant = (httpClient: HttpClient) => ({
     disabled?: boolean,
     parent?: string,
     roleInheritance?: '' | 'none' | 'userOnly',
+    enforceSSOExclusions?: string[],
   ): Promise<SdkResponse<never>> =>
     transformResponse(
       httpClient.post(apiPaths.tenant.create, {
@@ -50,6 +53,7 @@ const withTenant = (httpClient: HttpClient) => ({
         selfProvisioningDomains,
         customAttributes,
         enforceSSO,
+        enforceSSOExclusions,
         disabled,
         parent,
         roleInheritance,
@@ -63,6 +67,7 @@ const withTenant = (httpClient: HttpClient) => ({
     enforceSSO?: boolean,
     disabled?: boolean,
     roleInheritance?: '' | 'none' | 'userOnly',
+    enforceSSOExclusions?: string[],
   ): Promise<SdkResponse<never>> =>
     transformResponse(
       httpClient.post(apiPaths.tenant.update, {
@@ -71,6 +76,7 @@ const withTenant = (httpClient: HttpClient) => ({
         selfProvisioningDomains,
         customAttributes,
         enforceSSO,
+        enforceSSOExclusions,
         disabled,
         roleInheritance,
       }),

--- a/lib/management/types.ts
+++ b/lib/management/types.ts
@@ -190,8 +190,10 @@ export type Tenant = {
   domains?: string[];
   authType?: 'none' | 'saml' | 'oidc';
   enforceSSO?: boolean;
+  enforceSSOExclusions?: string[];
   disabled?: boolean;
   defaultRoles?: string[];
+  roleInheritance?: '' | 'none' | 'userOnly';
 };
 
 export type SSOSetupSuiteSettingsDisabledFeatures = {


### PR DESCRIPTION
The /v1/mgmt/tenant/create and /v1/mgmt/tenant/update endpoints accept enforceSSOExclusions and the Go SDK sends it on every write, but the Node SDK had no way to supply it. Since tenant update is a full replace, any Node SDK tenant write silently cleared an enforceSSOExclusions list set from the console or another SDK.

Also adds enforceSSOExclusions and roleInheritance to the Tenant read type; both are returned by GET /v1/mgmt/tenant but were missing, which made roleInheritance write-only and unpreservable in a read-modify-write.

## Related Issues

No Issue submitted for it.
Noticed during day-to-day working and submitted a PR.

## Description

`management.tenant.create`, `createWithId`, and `update` had no way to send
`enforceSSOExclusions`, even though the endpoints they POST to accept it. Because tenant
update is a **full replace**, this additionally made every Node SDK tenant write silently
erase an exclusions list configured from the console or another SDK.

This appends `enforceSSOExclusions?: string[]` as the **last** parameter of all three
methods and sends it in the request body. With this change, the Node SDK's tenant
create/update request surface matches the Go SDK's field for field.

## Must

- [x] Tests — extended the `create`, `createWithId`, and `update` blocks in
      `lib/management/tenant.test.ts` to pass the new argument and assert it in the expected
      POST body. The existing parent-tenant test variants were intentionally left without the
      new argument, so they continue to cover the omitted case. Full suite: 451/451 passing,
      coverage above the configured thresholds (statements 97.89%, functions 98.41%,
      lines 98.91% against a 97% gate).
- [x] Documentation (if applicable) — README tenant `create` and `update` examples now show
      `enforceSSOExclusions`, plus an explicit warning that fields omitted from `update` are
      cleared.
