### PR TITLE
ci: make Ready gate fail when required jobs fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,11 +146,7 @@ jobs:
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: |
           echo "One or more required jobs failed or were cancelled:"
-          echo "  build:          ${{ needs.build.result }}"
-          echo "  eslint:         ${{ needs.eslint.result }}"
-          echo "  gitleaks:       ${{ needs.gitleaks.result }}"
-          echo "  pr-title-check: ${{ needs.pr-title-check.result }}"
-          echo "  unit-test:      ${{ needs.unit-test.result }}"
+          echo '${{ toJSON(needs) }}'
           exit 1
       - name: Ready
         run: echo "All checks passed and the PR is ready to be merged!"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,20 @@ jobs:
     name: 🚀 Ready
     runs-on: ubuntu-latest
     needs: [build, eslint, gitleaks, pr-title-check, unit-test]
+    # Run even when a dependency fails or is skipped, so this required
+    # gate reports a real pass/fail instead of being auto-satisfied by
+    # a "skipped" status when an upstream job fails.
+    if: always()
     steps:
+      - name: Verify all required jobs succeeded
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "One or more required jobs failed or were cancelled:"
+          echo "  build:          ${{ needs.build.result }}"
+          echo "  eslint:         ${{ needs.eslint.result }}"
+          echo "  gitleaks:       ${{ needs.gitleaks.result }}"
+          echo "  pr-title-check: ${{ needs.pr-title-check.result }}"
+          echo "  unit-test:      ${{ needs.unit-test.result }}"
+          exit 1
       - name: Ready
         run: echo "All checks passed and the PR is ready to be merged!"


### PR DESCRIPTION
The `🚀  Ready` gate (the only required status check on `main`) has no `if: always()`, so when any upstream job fails the gate is **skipped** —
  and GitHub treats a skipped required check as satisfied. Combined with auto-approve + auto-squash, PRs merge over red CI (e.g. #776). This makes the gate
  run always and fail explicitly if any required job failed or was cancelled.