### PR TITLE
feat: add removeRecoveryCodes user management method

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,14 @@ Provide the `loginId` to the function to remove the user's TOTP seed.
 const response = await descopeClient.management.user.removeTOTPSeed(loginId);
 ```
 
+#### Deleting Recovery Codes
+
+Provide the `loginId` to the function to remove all of the user's recovery codes.
+
+```typescript
+const response = await descopeClient.management.user.removeRecoveryCodes(loginId);
+```
+
 ### Passwords
 
 The user can also authenticate with a password, though it's recommended to

--- a/lib/management/paths.ts
+++ b/lib/management/paths.ts
@@ -37,6 +37,7 @@ export default {
     expirePassword: '/v1/mgmt/user/password/expire',
     removeAllPasskeys: '/v1/mgmt/user/passkeys/delete',
     removeTOTPSeed: '/v1/mgmt/user/totp/delete',
+    removeRecoveryCodes: '/v1/mgmt/user/recovery-codes/delete',
     generateOTPForTest: '/v1/mgmt/tests/generate/otp',
     generateMagicLinkForTest: '/v1/mgmt/tests/generate/magiclink',
     generateEnchantedLinkForTest: '/v1/mgmt/tests/generate/enchantedlink',

--- a/lib/management/user.test.ts
+++ b/lib/management/user.test.ts
@@ -2414,6 +2414,34 @@ describe('Management User', () => {
     });
   });
 
+  describe('removeRecoveryCodes', () => {
+    it('should send the correct request and receive correct response', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => {},
+        clone: () => ({
+          json: () => Promise.resolve({}),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const loginId = 'some-id';
+      const resp = await management.user.removeRecoveryCodes(loginId);
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.removeRecoveryCodes, {
+        loginId,
+      });
+
+      expect(resp).toEqual({
+        code: 200,
+        data: {},
+        ok: true,
+        response: httpResponse,
+      });
+    });
+  });
+
   describe('history', () => {
     it('should send the correct request and receive correct response', async () => {
       const usersHistoryRes = [

--- a/lib/management/user.ts
+++ b/lib/management/user.ts
@@ -1076,6 +1076,18 @@ const withUser = (httpClient: HttpClient) => {
       ),
 
     /**
+     * Removes all recovery codes for the user with the given login ID.
+     * Note: The user might not be able to login anymore if they have no other authentication
+     * methods or a verified email/phone.
+     * @param loginId The login ID of the user
+     */
+    removeRecoveryCodes: (loginId: string): Promise<SdkResponse<never>> =>
+      transformResponse<never>(
+        httpClient.post(apiPaths.user.removeRecoveryCodes, { loginId }),
+        (data) => data,
+      ),
+
+    /**
      * Retrieve users' authentication history, by the given user's ids.
      * @param userIds The user IDs
      */

--- a/lib/management/user.ts
+++ b/lib/management/user.ts
@@ -1077,8 +1077,8 @@ const withUser = (httpClient: HttpClient) => {
 
     /**
      * Removes all recovery codes for the user with the given login ID.
-     * Note: The user might not be able to login anymore if they have no other authentication
-     * methods or a verified email/phone.
+     * Note: The user will no longer be able to sign in with any previously
+     * generated recovery codes.
      * @param loginId The login ID of the user
      */
     removeRecoveryCodes: (loginId: string): Promise<SdkResponse<never>> =>


### PR DESCRIPTION
## Related Issues
Required for:
https://github.com/descope/etc/issues/17502

## Related PRs
### Related PRs
- https://github.com/descope/backend/pull/2092
- https://github.com/descope/go-sdk/pull/818
- https://github.com/descope/python-sdk/pull/1643

## In a Nutshell
- Add `removeRecoveryCodes` user management method

## Description
Adds the SDK wrapper for the new backend endpoint `POST /v1/mgmt/user/recovery-codes/delete` (descope/backend#2092), which revokes all of a user's recovery codes. Mirrors the existing `removeTOTPSeed` method.

## Must
- [x] Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

