### PR TITLE
docs(mgmt): removeRecoveryCodes accepts login ID or user ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,10 +365,10 @@ const response = await descopeClient.management.user.removeTOTPSeed(loginId);
 
 #### Deleting Recovery Codes
 
-Provide the `loginId` to the function to remove all of the user's recovery codes.
+Provide a login ID or user ID to the function to remove all of the user's recovery codes.
 
 ```typescript
-const response = await descopeClient.management.user.removeRecoveryCodes(loginId);
+const response = await descopeClient.management.user.removeRecoveryCodes(loginIdOrUserId);
 ```
 
 ### Passwords

--- a/lib/management/user.test.ts
+++ b/lib/management/user.test.ts
@@ -2426,11 +2426,11 @@ describe('Management User', () => {
       };
       mockHttpClient.post.mockResolvedValue(httpResponse);
 
-      const loginId = 'some-id';
-      const resp = await management.user.removeRecoveryCodes(loginId);
+      const loginIdOrUserId = 'some-id';
+      const resp = await management.user.removeRecoveryCodes(loginIdOrUserId);
 
       expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.user.removeRecoveryCodes, {
-        loginId,
+        loginId: loginIdOrUserId,
       });
 
       expect(resp).toEqual({

--- a/lib/management/user.ts
+++ b/lib/management/user.ts
@@ -1076,14 +1076,14 @@ const withUser = (httpClient: HttpClient) => {
       ),
 
     /**
-     * Removes all recovery codes for the user with the given login ID.
+     * Removes all recovery codes for the user with the given login ID or user ID.
      * Note: The user will no longer be able to sign in with any previously
      * generated recovery codes.
-     * @param loginId The login ID of the user
+     * @param loginIdOrUserId The login ID or user ID of the user
      */
-    removeRecoveryCodes: (loginId: string): Promise<SdkResponse<never>> =>
+    removeRecoveryCodes: (loginIdOrUserId: string): Promise<SdkResponse<never>> =>
       transformResponse<never>(
-        httpClient.post(apiPaths.user.removeRecoveryCodes, { loginId }),
+        httpClient.post(apiPaths.user.removeRecoveryCodes, { loginId: loginIdOrUserId }),
         (data) => data,
       ),
 


### PR DESCRIPTION
## Related Issues
Required for:
https://github.com/descope/etc/issues/17502

## Related PRs
### Related PRs
- https://github.com/descope/backend/pull/2092
- https://github.com/descope/node-sdk/pull/784

## In a Nutshell
- `removeRecoveryCodes` accepts a login ID or user ID

## Description
Follow-up to #784: the backend resolves the identifier as either a login ID or a user ID (descope/backend#2092), and the public API field is named `identifier` like the other user endpoints. Rename the parameter to `loginIdOrUserId` and update docs to match the SDK's dual-ID convention (`delete`, `update`). No wire change.

## Must
- [x] Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)