### PR TITLE
feat(sso): add configureAuthType to enable or disable an SSO configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1102,6 +1102,13 @@ await descopeClient.management.sso.newSettings(tenantID, ssoId, displayName);
 // You can delete existing SSO configuration
 // You can pass ssoId in case using multi SSO and you want to delete specific SSO configuration
 await descopeClient.management.sso.deleteSettings(tenantID);
+
+// You can disable an SSO configuration without deleting it, and enable it again later.
+// Its settings, mappings and domains are kept, so re-enabling needs no payload.
+// You can pass ssoId in case using multi SSO and you want to disable a specific SSO configuration
+await descopeClient.management.sso.configureAuthType(tenantID, 'none', ssoId);
+// Enable it again on the protocol it is configured for ('saml' or 'oidc')
+await descopeClient.management.sso.configureAuthType(tenantID, 'saml', ssoId);
 ```
 
 Note: Certificates should have a similar structure to:

--- a/lib/management/paths.ts
+++ b/lib/management/paths.ts
@@ -144,6 +144,7 @@ export default {
   sso: {
     settings: '/v1/mgmt/sso/settings',
     settingsNew: '/v1/mgmt/sso/settings/new',
+    authType: '/v1/mgmt/sso/settings/authtype',
     metadata: '/v1/mgmt/sso/metadata',
     mapping: '/v1/mgmt/sso/mapping',
     settingsv2: '/v2/mgmt/sso/settings',

--- a/lib/management/sso.test.ts
+++ b/lib/management/sso.test.ts
@@ -484,6 +484,61 @@ describe('Management SSO', () => {
     });
   });
 
+  describe('configureAuthType', () => {
+    it('should disable a specific SSO configuration', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => {},
+        clone: () => ({
+          json: () => Promise.resolve({}),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const resp = await management.sso.configureAuthType('t1', 'none', 'conf1');
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.sso.authType, {
+        tenantId: 't1',
+        authType: 'none',
+        ssoId: 'conf1',
+      });
+
+      expect(resp).toEqual({
+        code: 200,
+        ok: true,
+        response: httpResponse,
+        data: {},
+      });
+    });
+
+    it('should target the default configuration when no ssoId is given', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => {},
+        clone: () => ({
+          json: () => Promise.resolve({}),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      const resp = await management.sso.configureAuthType('t1', 'saml');
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.sso.authType, {
+        tenantId: 't1',
+        authType: 'saml',
+      });
+
+      expect(resp).toEqual({
+        code: 200,
+        ok: true,
+        response: httpResponse,
+        data: {},
+      });
+    });
+  });
+
   describe('newSettings', () => {
     it('should send the correct request and receive correct response', async () => {
       const mockResponse = {

--- a/lib/management/sso.ts
+++ b/lib/management/sso.ts
@@ -8,6 +8,7 @@ import {
   SSOSAMLSettings,
   SSOSAMLByMetadataSettings,
   SSOSettings,
+  SSOAuthType,
   XAASettings,
   XAASettingsResponse,
 } from './types';
@@ -156,6 +157,26 @@ const withSSOSettings = (httpClient: HttpClient) => ({
       }),
     );
   },
+  /**
+   * Set the authentication type of a single SSO configuration, leaving its stored SAML/OIDC
+   * settings, mappings and domains untouched. `none` disables the configuration without deleting
+   * it, `saml`/`oidc` enable it on that protocol.
+   * @param tenantId the tenant the configuration belongs to
+   * @param authType `none` to disable, `saml` or `oidc` to enable on that protocol
+   * @param ssoId the SSO configuration to change; omit for the tenant's default configuration
+   */
+  configureAuthType: (
+    tenantId: string,
+    authType: SSOAuthType,
+    ssoId?: string,
+  ): Promise<SdkResponse<never>> =>
+    transformResponse(
+      httpClient.post(apiPaths.sso.authType, {
+        tenantId,
+        authType,
+        ...(ssoId ? { ssoId } : {}),
+      }),
+    ),
   configureSAMLSettings: (
     tenantId: string,
     settings: SSOSAMLSettings,

--- a/lib/management/types.ts
+++ b/lib/management/types.ts
@@ -247,6 +247,12 @@ export type ClientAssertionResponse = {
 /** Represents a tenant in a project. It has an id, a name and an array of
  * self provisioning domains used to associate users with that tenant.
  */
+/** Authentication type of an SSO configuration. `none` means the configuration is disabled: it
+ * keeps its stored settings, mappings and domains, and serves no logins until it is set back to
+ * `saml` or `oidc`.
+ */
+export type SSOAuthType = 'none' | 'saml' | 'oidc';
+
 export type Tenant = {
   id: string;
   name: string;
@@ -254,7 +260,7 @@ export type Tenant = {
   createdTime: number;
   customAttributes?: Record<string, string | number | boolean | string[]>;
   domains?: string[];
-  authType?: 'none' | 'saml' | 'oidc';
+  authType?: SSOAuthType;
   enforceSSO?: boolean;
   disabled?: boolean;
   defaultRoles?: string[];
@@ -280,7 +286,7 @@ export type SSOSetupSuiteSettings = {
 export type TenantSettings = {
   selfProvisioningDomains: string[];
   domains?: string[];
-  authType?: 'none' | 'saml' | 'oidc';
+  authType?: SSOAuthType;
   enabled?: boolean;
   refreshTokenExpiration?: number;
   refreshTokenExpirationUnit?: ExpirationUnit;


### PR DESCRIPTION
## Description

Wraps the new management endpoint `POST /v1/mgmt/sso/settings/authtype`

```ts
// disable one connection of a multi-SSO tenant, keeping its configuration
await descopeClient.management.sso.configureAuthType('tenant-id', 'none', 'conf1');
// enable it again on the protocol it is configured for
await descopeClient.management.sso.configureAuthType('tenant-id', 'saml', 'conf1');
// omit ssoId to target the tenant's default configuration
await descopeClient.management.sso.configureAuthType('tenant-id', 'none');
```

**Why.** A customer running their own admin UI on the management APIs needs to temporarily disable one SSO connection of a multi-SSO tenant. Until now the only per-connection off switch was `deleteSettings`, which drops the connection: re-enabling meant `newSettings` plus a full `configureSAMLSettings` / `configureOIDCSettings` replay, and the caller had to store the mappings, the domains and the OIDC `clientSecret` (never returned on read). For SAML it was worse, since a recreated connection gets a new ACS URL and the tenant's IdP admin has to reconfigure. `configureAuthType` keeps the stored configuration intact, so re-enabling needs no payload.

Also names the `'none' | 'saml' | 'oidc'` union `SSOAuthType` and reuses it on `Tenant` and `TenantSettings`, which both already inlined it. Type-identical, so not a breaking change.

## Tests

`lib/management/sso.test.ts` — the request shape with an `ssoId`, and the default-configuration call that omits it. Full suite green.
