### PR TITLE
feat(xaa): expose the read-only project-level audience on the XAA load response

### DIFF
--- a/lib/management/sso.test.ts
+++ b/lib/management/sso.test.ts
@@ -996,6 +996,7 @@ describe('Management SSO', () => {
         groupsMapping: [{ role: { id: 'r1', name: 'role1' }, groups: ['g1'] }],
         defaultSSORoles: ['Member'],
         providerID: 'okta',
+        audience: 'https://api.descope.com/v1/apps/P1',
       };
       const httpResponse = {
         ok: true,
@@ -1010,6 +1011,8 @@ describe('Management SSO', () => {
       const resp = await management.sso.loadXAASettings('t1', 'somessoid');
       // providerID round-trips through transformXAASettingsResponse (no explicit copy needed).
       expect(resp.data?.providerID).toBe('okta');
+      // Read-only, project-level: no tenant segment - the tenant travels in the aud_tenant claim.
+      expect(resp.data?.audience).toBe('https://api.descope.com/v1/apps/P1');
 
       expect(mockHttpClient.get).toHaveBeenCalledWith(apiPaths.sso.xaa.settings, {
         queryParams: { tenantId: 't1', ssoId: 'somessoid' },

--- a/lib/management/types.ts
+++ b/lib/management/types.ts
@@ -232,6 +232,10 @@ export type XAASettingsResponse = {
   groupPriorityEnabled?: boolean;
   allowOverrideRoles?: boolean;
   providerID?: string;
+  /** Read-only: the project-level audience a requesting application must present in its ID-JAG token.
+   * It carries no tenant segment - it equals the issuer the project publishes - so the identity
+   * provider must send the tenant id in the token's `aud_tenant` claim. */
+  audience?: string;
 };
 
 /** UpdateJWT response with a new JWT value with the added custom claims */


### PR DESCRIPTION
## Related Issues
Required for:
https://github.com/descope/etc/issues/18013

## Related PRs
### Upstream PRs
- https://github.com/descope/backend/pull/2378

### Related PRs
- https://github.com/descope/console-app/pull/5734
- https://github.com/descope/descope-apps/pull/864
- https://github.com/descope/content/pull/2273
- https://github.com/descope/go-sdk/pull/839
- https://github.com/descope/python-sdk/pull/1677
- https://github.com/descope/integrationtests/pull/14790

## In a Nutshell
- Read-only `audience` on the XAA load response

## Description
Loading Cross-App Access settings now also returns the audience a requesting application has to present in its ID-JAG token, so callers read the same value the console shows instead of building it themselves. It has no tenant in it - the identity provider sends the tenant in the token's `aud_tenant` claim.

## Must
- [x] Tests
- [ ] Documentation (if applicable)
