### PR TITLE
feat(tenant): add patchTenant for partial tenant updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,6 +639,13 @@ await descopeClient.management.tenant.update(
   { customAttributeName: 'val' },
 );
 
+// Unlike update, patchTenant only changes the fields you provide - everything else
+// (domains, customAttributes, enforceSSO, ...) is left untouched.
+await descopeClient.management.tenant.patchTenant('my-custom-id', {
+  name: 'My Tenant',
+  disabled: true,
+});
+
 // Update the tenant's default roles by providing role names.
 // These are project-level roles that will be automatically assigned to users in this tenant.
 await descopeClient.management.tenant.updateDefaultRoles('my-custom-id', ['role1', 'role2']);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -530,3 +530,4 @@ export type { AuthenticationInfo, IDPResponse, RefreshAuthenticationInfo };
 export type { VerifyOptions } from './types';
 export * from './management/types';
 export type { PatchUserOptions } from './management/user';
+export type { PatchTenantOptions } from './management/tenant';

--- a/lib/management/paths.ts
+++ b/lib/management/paths.ts
@@ -82,6 +82,7 @@ export default {
   tenant: {
     create: '/v1/mgmt/tenant/create',
     update: '/v1/mgmt/tenant/update',
+    patch: '/v1/mgmt/tenant/patch',
     delete: '/v1/mgmt/tenant/delete',
     load: '/v1/mgmt/tenant',
     settings: '/v1/mgmt/tenant/settings',

--- a/lib/management/tenant.test.ts
+++ b/lib/management/tenant.test.ts
@@ -302,6 +302,77 @@ describe('Management Tenant', () => {
     });
   });
 
+  describe('patchTenant', () => {
+    it('should send the correct request and receive correct response for a full call', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => {},
+        clone: () => ({
+          json: () => Promise.resolve({}),
+        }),
+        status: 200,
+      };
+      mockHttpClient.patch.mockResolvedValue(httpResponse);
+
+      const resp = await management.tenant.patchTenant('t1', {
+        name: 'name',
+        selfProvisioningDomains: ['d1'],
+        customAttributes: { customAttr: 'value' },
+        authType: 'saml',
+        disabled: true,
+        enforceSSO: true,
+        enforceSSOExclusions: ['e1'],
+        federatedAppIds: ['app1'],
+        roleInheritance: 'none',
+      });
+
+      expect(mockHttpClient.patch).toHaveBeenCalledWith(apiPaths.tenant.patch, {
+        id: 't1',
+        name: 'name',
+        selfProvisioningDomains: ['d1'],
+        customAttributes: { customAttr: 'value' },
+        authType: 'saml',
+        disabled: true,
+        enforceSSO: true,
+        enforceSSOExclusions: ['e1'],
+        federatedAppIds: ['app1'],
+        roleInheritance: 'none',
+      });
+
+      expect(resp).toEqual({
+        code: 200,
+        data: {},
+        ok: true,
+        response: httpResponse,
+      });
+    });
+
+    it('should send only the id when no options are provided', async () => {
+      const httpResponse = {
+        ok: true,
+        json: () => {},
+        clone: () => ({
+          json: () => Promise.resolve({}),
+        }),
+        status: 200,
+      };
+      mockHttpClient.patch.mockResolvedValue(httpResponse);
+
+      const resp = await management.tenant.patchTenant('t1');
+
+      expect(mockHttpClient.patch).toHaveBeenCalledWith(apiPaths.tenant.patch, {
+        id: 't1',
+      });
+
+      expect(resp).toEqual({
+        code: 200,
+        data: {},
+        ok: true,
+        response: httpResponse,
+      });
+    });
+  });
+
   describe('delete', () => {
     it('should send the correct request and receive correct response', async () => {
       const httpResponse = {

--- a/lib/management/tenant.ts
+++ b/lib/management/tenant.ts
@@ -77,6 +77,24 @@ const withTenant = (httpClient: HttpClient) => ({
     ),
   updateDefaultRoles: (id: string, defaultRoles: string[]): Promise<SdkResponse<never>> =>
     transformResponse(httpClient.post(apiPaths.tenant.updateDefaultRoles, { id, defaultRoles })),
+  patchTenant: (id: string, options?: PatchTenantOptions): Promise<SdkResponse<never>> => {
+    const body: Record<string, unknown> = { id };
+    if (options?.name !== undefined) body.name = options.name;
+    if (options?.selfProvisioningDomains !== undefined) {
+      body.selfProvisioningDomains = options.selfProvisioningDomains;
+    }
+    if (options?.customAttributes !== undefined) body.customAttributes = options.customAttributes;
+    if (options?.authType !== undefined) body.authType = options.authType;
+    if (options?.disabled !== undefined) body.disabled = options.disabled;
+    if (options?.enforceSSO !== undefined) body.enforceSSO = options.enforceSSO;
+    if (options?.enforceSSOExclusions !== undefined) {
+      body.enforceSSOExclusions = options.enforceSSOExclusions;
+    }
+    if (options?.federatedAppIds !== undefined) body.federatedAppIds = options.federatedAppIds;
+    if (options?.roleInheritance !== undefined) body.roleInheritance = options.roleInheritance;
+
+    return transformResponse(httpClient.patch(apiPaths.tenant.patch, body));
+  },
   delete: (id: string, cascade?: boolean): Promise<SdkResponse<never>> =>
     transformResponse(httpClient.post(apiPaths.tenant.delete, { id, cascade })),
   load: (id: string): Promise<SdkResponse<Tenant>> =>
@@ -145,5 +163,18 @@ const withTenant = (httpClient: HttpClient) => ({
       ),
     ),
 });
+
+export interface PatchTenantOptions {
+  name?: string;
+  selfProvisioningDomains?: string[];
+  customAttributes?: Record<string, unknown>;
+  /** @deprecated kept for compatibility */
+  authType?: string;
+  disabled?: boolean;
+  enforceSSO?: boolean;
+  enforceSSOExclusions?: string[];
+  federatedAppIds?: string[];
+  roleInheritance?: string;
+}
 
 export default withTenant;

--- a/lib/management/tenant.ts
+++ b/lib/management/tenant.ts
@@ -167,14 +167,14 @@ const withTenant = (httpClient: HttpClient) => ({
 export interface PatchTenantOptions {
   name?: string;
   selfProvisioningDomains?: string[];
-  customAttributes?: Record<string, unknown>;
+  customAttributes?: Record<string, AttributesTypes>;
   /** @deprecated kept for compatibility */
   authType?: string;
   disabled?: boolean;
   enforceSSO?: boolean;
   enforceSSOExclusions?: string[];
   federatedAppIds?: string[];
-  roleInheritance?: string;
+  roleInheritance?: '' | 'none' | 'userOnly';
 }
 
 export default withTenant;


### PR DESCRIPTION
## Related Issues

related to https://github.com/descope/etc/issues/17551

## Description

Wraps the management endpoint `PATCH /v1/mgmt/tenant/patch` to support partial tenant structure updates.
## Must

- [x] Tests
- [x] Documentation (if applicable)

