### PR TITLE
feat(sso): allow disabling SAML AuthnRequest signing per SSO configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1062,14 +1062,14 @@ const allSSOSettings = await descopeClient.management.sso.loadAllSettings('tenan
 // You can configure SSO settings manually by setting the required fields directly
 // You can pass ssoId in case using multi SSO and you want to configure specific SSO configuration
 const tenantId = 'tenant-id'; // Which tenant this configuration is for
-const idpURL = 'https://idp.com';
-const entityID = 'my-idp-entity-id';
+const idpUrl = 'https://idp.com';
+const entityId = 'my-idp-entity-id';
 const idpCert = '<your-cert-here>';
 const redirectURL = 'https://my-app.com/handle-sso'; // Global redirect URL for SSO/SAML
 const domains = ['tenant-users.com']; // Users authentication with this domain will be logged in to this tenant
 await descopeClient.management.sso.configureSAMLSettings(
   tenantID,
-  { idpURL, entityID, idpCert },
+  { idpUrl, entityId, idpCert },
   redirectURL,
   domains,
 );
@@ -1088,7 +1088,7 @@ await descopeClient.management.sso.configureSAMLByMetadata(
 // settings (available on both variants above) to send the request unsigned for that configuration only.
 await descopeClient.management.sso.configureSAMLSettings(
   tenantID,
-  { idpURL, entityID, idpCert, disableSignRequest: true },
+  { idpUrl, entityId, idpCert, disableSignRequest: true },
   redirectURL,
   domains,
 );

--- a/README.md
+++ b/README.md
@@ -1083,6 +1083,16 @@ await descopeClient.management.sso.configureSAMLByMetadata(
   domains,
 );
 
+// Descope signs the SAML AuthnRequest it sends to the IdP. A few IdPs reject a signed request because
+// their trusted provider entry holds no signing certificate for Descope - pass disableSignRequest on the
+// settings (available on both variants above) to send the request unsigned for that configuration only.
+await descopeClient.management.sso.configureSAMLSettings(
+  tenantID,
+  { idpURL, entityID, idpCert, disableSignRequest: true },
+  redirectURL,
+  domains,
+);
+
 // In case SSO is configured to work with OIDC use the following
 // You can pass ssoId in case using multi SSO and you want to configure specific SSO configuration
 const name = 'some-name';

--- a/lib/management/sso.test.ts
+++ b/lib/management/sso.test.ts
@@ -394,6 +394,67 @@ describe('Management SSO', () => {
     });
   });
 
+  describe('configureSAMLSettings disableSignRequest', () => {
+    it.each([true, false])('should pass disableSignRequest=%s through', async (disable) => {
+      const httpResponse = {
+        ok: true,
+        clone: () => ({
+          json: () => Promise.resolve(),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValue(httpResponse);
+
+      await management.sso.configureSAMLSettings('t1', {
+        idpUrl: 'https://idp.url',
+        entityId: 'eid',
+        idpCert: 'bsae64cert',
+        disableSignRequest: disable,
+      });
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.sso.saml.configure, {
+        tenantId: 't1',
+        settings: {
+          idpUrl: 'https://idp.url',
+          entityId: 'eid',
+          idpCert: 'bsae64cert',
+          disableSignRequest: disable,
+        },
+        redirectUrl: undefined,
+        domains: undefined,
+      });
+    });
+
+    it.each([true, false])(
+      'should pass disableSignRequest=%s through the metadata variant',
+      async (disable) => {
+        const httpResponse = {
+          ok: true,
+          clone: () => ({
+            json: () => Promise.resolve(),
+          }),
+          status: 200,
+        };
+        mockHttpClient.post.mockResolvedValue(httpResponse);
+
+        await management.sso.configureSAMLByMetadata('t1', {
+          idpMetadataUrl: 'https://idp.url/metadata',
+          disableSignRequest: disable,
+        });
+
+        expect(mockHttpClient.post).toHaveBeenCalledWith(apiPaths.sso.saml.metadata, {
+          tenantId: 't1',
+          settings: {
+            idpMetadataUrl: 'https://idp.url/metadata',
+            disableSignRequest: disable,
+          },
+          redirectUrl: undefined,
+          domains: undefined,
+        });
+      },
+    );
+  });
+
   describe('configureSAMLByMetadata', () => {
     it('should send the correct request and receive correct response', async () => {
       const httpResponse = {

--- a/lib/management/types.ts
+++ b/lib/management/types.ts
@@ -643,6 +643,8 @@ export type SSOSAMLSettingsResponse = {
   scimProviderID?: string;
   /** Epoch seconds of the last successful SSO test login on this configuration (read-only) */
   lastSuccessTestTime?: number;
+  /** True when Descope sends the SAML AuthnRequest to this IdP unsigned */
+  disableSignRequest?: boolean;
 };
 
 export type SSOSettings = {
@@ -705,6 +707,12 @@ export type SSOSAMLSettings = {
   roleMappings?: RoleMappings;
   attributeMapping?: AttributeMapping;
   defaultSSORoles?: string[];
+  /**
+   * Leave the SAML AuthnRequest Descope sends to the IdP unsigned. Set it only for IdPs that reject a
+   * signed request because their trusted provider entry holds no signing certificate for Descope.
+   * Defaults to false, i.e. requests are signed.
+   */
+  disableSignRequest?: boolean;
 
   // NOTICE - the following fields should be overridden only in case of SSO migration, otherwise, do not modify these fields
   spACSUrl?: string;
@@ -718,6 +726,12 @@ export type SSOSAMLByMetadataSettings = {
   roleMappings?: RoleMappings;
   attributeMapping?: AttributeMapping;
   defaultSSORoles?: string[];
+  /**
+   * Leave the SAML AuthnRequest Descope sends to the IdP unsigned. Set it only for IdPs that reject a
+   * signed request because their trusted provider entry holds no signing certificate for Descope.
+   * Defaults to false, i.e. requests are signed.
+   */
+  disableSignRequest?: boolean;
 
   // NOTICE - the following fields should be overridden only in case of SSO migration, otherwise, do not modify these fields
   spACSUrl?: string;


### PR DESCRIPTION
## Description

Issue: https://github.com/descope/etc/issues/18144
go-sdk: https://github.com/descope/go-sdk/pull/842 · python-sdk: https://github.com/descope/python-sdk/pull/1684

Descope signs the SAML `AuthnRequest` it sends to a tenant's IdP. A few IdPs (NetIQ Access Manager among them) reject a signed request outright when their trusted-provider entry holds no signing certificate for Descope, and until now there was no way to opt out.

This exposes the new per-SSO-configuration flag:

- `disableSignRequest?: boolean` on `SSOSAMLSettings` and `SSOSAMLByMetadataSettings`.
- `disableSignRequest?: boolean` on `SSOSAMLSettingsResponse`, so the stored value is readable.

The settings object is posted through as-is, so an omitted flag means the server default — signed — which is exactly the behavior every existing caller has today.
